### PR TITLE
Add support for --info to podman register command

### DIFF
--- a/doc/flake-ctl-podman-register.rst
+++ b/doc/flake-ctl-podman-register.rst
@@ -16,13 +16,14 @@ SYNOPSIS
 
    OPTIONS:
        --app <APP>
-       --attach <true|false>
+       --attach
        --base <BASE>
        --container <CONTAINER>
        --include-tar <INCLUDE_TAR>...
+       --info
        --layer <LAYER>...
        --opt <OPT>...
-       --resume <true|false>
+       --resume
        --run-as <RUN_AS>
        --target <TARGET>
 
@@ -51,7 +52,7 @@ OPTIONS
   specified via the target option, the application will be
   called with that path inside of the container
 
---attach <ATTACH>
+--attach
 
   Attach to the container if still running, rather than executing
   the app again. Only makes sense for interactive sessions like a
@@ -72,6 +73,10 @@ OPTIONS
   Name of a tar file to be included on top of the container instance.
   This option can be specified multiple times
 
+--info
+
+  Print registration information from container if provided
+
 --layer <LAYER>...
 
   Name of an additional container layer on top of the specified
@@ -90,7 +95,7 @@ OPTIONS
   default settings will apply. See the example section for further
   details.
 
---resume <RESUME>
+--resume
 
   Resume the container from previous execution. If the container is
   still running, the app will be executed inside of this container

--- a/flake-ctl/src/app_config.rs
+++ b/flake-ctl/src/app_config.rs
@@ -65,8 +65,8 @@ impl AppConfig {
         base: Option<&String>,
         layers: Option<Vec<String>>,
         includes_tar: Option<Vec<String>>,
-        resume: Option<&bool>,
-        attach: Option<&bool>,
+        resume: bool,
+        attach: bool,
         run_as: Option<&String>,
         opts: Option<Vec<String>>
     ) -> Result<(), GenericError> {
@@ -92,12 +92,12 @@ impl AppConfig {
                 layers.as_ref().unwrap().to_vec()
             );
         }
-        if ! resume.is_none() && *resume.unwrap() == true {
+        if resume {
             yaml_config.container.runtime.as_mut().unwrap()
-                .resume = Some(*resume.unwrap());
-        } else if ! attach.is_none() && *attach.unwrap() == true {
+                .resume = Some(resume);
+        } else if attach {
             yaml_config.container.runtime.as_mut().unwrap()
-                .attach = Some(*attach.unwrap());
+                .attach = Some(attach);
         } else {
             // default: remove the container if no resume/attach is set
             yaml_config.container.runtime.as_mut().unwrap()

--- a/flake-ctl/src/cli.rs
+++ b/flake-ctl/src/cli.rs
@@ -75,9 +75,16 @@ pub enum Podman {
         app: Option<String>,
     },
     /// Register container application
-    #[clap(group(
-        ArgGroup::new("register").required(false).args(&["resume", "attach"]),
-    ))]
+    #[clap(
+        group(
+            ArgGroup::new("register")
+                .required(false).args(&["resume", "attach"])
+        ),
+        group(
+            ArgGroup::new("application")
+                .required(true).args(&["app", "info"])
+        )
+    )]
     Register {
         /// A container name. The name must match with a
         /// name in the local podman registry
@@ -89,7 +96,7 @@ pub enum Podman {
         /// application will be called with that path inside
         /// of the container.
         #[clap(long)]
-        app: String,
+        app: Option<String>,
 
         /// An absolute path to the application in the container.
         /// Use this option if the application path on the host
@@ -123,13 +130,13 @@ pub enum Podman {
         /// If the container is still running, the app will be
         /// executed inside of this container instance.
         #[clap(long)]
-        resume: Option<bool>,
+        resume: bool,
 
         /// Attach to the container if still running, rather than
         /// executing the app again. Only makes sense for interactive
         /// sessions like a shell application.
         #[clap(long)]
-        attach: Option<bool>,
+        attach: bool,
 
         /// Name of the user to run podman. Note: This requires
         /// rootless podman to be configured on the host. It's also
@@ -145,6 +152,10 @@ pub enum Podman {
         /// specified multiple times.
         #[clap(long, multiple = true)]
         opt: Option<Vec<String>>,
+
+        /// Print registration information from container if provided
+        #[clap(long)]
+        info: bool,
     },
     /// Build container package
     BuildDeb {

--- a/flake-ctl/src/defaults.rs
+++ b/flake-ctl/src/defaults.rs
@@ -21,9 +21,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-pub const CONTAINER_FLAKE_DIR: &str =
+pub const FLAKE_DIR: &str =
     "/usr/share/flakes";
-pub const PILOT: &str =
+pub const PODMAN_PILOT: &str =
     "/usr/bin/podman-pilot";
 pub const OCIDEB: &str =
     "/usr/bin/oci-deb";

--- a/flake-ctl/src/main.rs
+++ b/flake-ctl/src/main.rs
@@ -66,20 +66,22 @@ fn main() {
                 // register
                 cli::Podman::Register {
                     container, app, target, base,
-                    layer, include_tar, resume, attach, run_as, opt
+                    layer, include_tar, resume, attach, run_as, opt, info
                 } => {
                     if app::init() {
                         app::register(
                             container,
-                            app,
+                            app.as_ref(),
                             target.as_ref(),
                             base.as_ref(),
                             layer.as_ref().cloned(),
                             include_tar.as_ref().cloned(),
-                            resume.as_ref(),
-                            attach.as_ref(),
+                            *resume,
+                            *attach,
                             run_as.as_ref(),
-                            opt.as_ref().cloned()
+                            opt.as_ref().cloned(),
+                            *info,
+                            defaults::PODMAN_PILOT
                         );
                     }
                 },
@@ -87,12 +89,14 @@ fn main() {
                 cli::Podman::Remove { container, app } => {
                     if ! app.is_none() {
                         app::remove(
-                            app.as_ref().map(String::as_str).unwrap()
+                            app.as_ref().map(String::as_str).unwrap(),
+                            defaults::PODMAN_PILOT
                         );
                     }
                     if ! container.is_none() {
                         app::purge(
-                            container.as_ref().map(String::as_str).unwrap()
+                            container.as_ref().map(String::as_str).unwrap(),
+                            defaults::PODMAN_PILOT
                         );
                     }
                 }


### PR DESCRIPTION
If provided in the container the --info command will print the embedded default registration information. Along with the change some refactoring on the option handling as well as moving code engine specific vs. generic registration implementation. This Fixes #67