### PR TITLE
Added support for flake-ctl firecracker pull

### DIFF
--- a/.github/workflows/ci-compile.yml
+++ b/.github/workflows/ci-compile.yml
@@ -1,0 +1,27 @@
+name: CI-Compile
+  
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo:
+    name: Cargo Compile Components
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install
+        run: |
+          sudo apt update
+          sudo apt install cargo
+          sudo ln -s bash /bin/sh.bash
+          sudo mv /bin/sh.bash /bin/sh
+      - name: Compile
+        run: |
+          make cargo

--- a/Makefile
+++ b/Makefile
@@ -97,3 +97,8 @@ uninstall:
 
 man:
 	${MAKE} -C doc man
+
+cargo:
+	for path in $(shell find . -name Cargo.toml ! -path "*/vendor/*");do \
+		pushd `dirname $$path`; cargo build || exit 1; popd;\
+	done

--- a/doc/flake-ctl-firecracker-pull.rst
+++ b/doc/flake-ctl-firecracker-pull.rst
@@ -1,0 +1,78 @@
+FLAKE-CTL-FIRECRACKER-PULL(8)
+=============================
+
+NAME
+----
+
+**flake-ctl firecracker pull** - Fetch firecracker image
+
+SYNOPSIS
+--------
+
+.. code:: bash
+
+   USAGE:
+       flake-ctl firecracker pull [OPTIONS] --name <NAME> --kis-image <KIS_IMAGE>
+
+   OPTIONS:
+       --force
+       --kis-image <KIS_IMAGE>
+       --name <NAME>
+
+DESCRIPTION
+-----------
+
+Pull the components of a firecracker image from the given location
+into `/var/lib/firecracker/images/NAME` on the local machine.
+After completion the available firecracker images can be listed via:
+
+.. code:: bash
+
+   $ tree /var/lib/firecracker/images
+
+and shows a file structure like in the following example
+
+.. code:: bash
+
+   /var/lib/firecracker/images
+   └── myImage
+        ├── initrd
+        ├── kernel
+        └── rootfs
+
+OPTIONS
+-------
+
+--force
+
+  Force pulling the image even if it already exists This will wipe
+  existing data for the provided identifier
+
+--kis-image <KIS_IMAGE>
+
+  Firecracker image built by KIWI as kis image type to pull
+  into local image store. This means the file behind KIS_IMAGE
+  is expected to be a tarball containing the KIS
+  components; rootfs-image, kernel and optional initrd
+
+--name <NAME>
+
+  Image name used as local identifier
+
+EXAMPLE
+-------
+
+.. code:: bash
+
+   $ flake-ctl firecracker pull --name myImage --kis-image \
+       https://download.opensuse.org/repositories/home:/marcus.schaefer:/delta_containers/images/firecracker-basesystem.x86_64.tar.xz
+
+AUTHOR
+------
+
+Marcus Schäfer
+
+COPYRIGHT
+---------
+
+(c) 2022, Elektrobit Automotive GmbH

--- a/doc/flake-ctl-podman-build-deb.rst
+++ b/doc/flake-ctl-podman-build-deb.rst
@@ -1,10 +1,10 @@
-FLAKE-CTL-BUILD-DEB(8)
-======================
+FLAKE-CTL-PODMAN-BUILD-DEB(8)
+=============================
 
 NAME
 ----
 
-**flake-ctl build-deb** - Build debian package from OCI image
+**flake-ctl podman build-deb** - Build debian package from OCI image
 
 SYNOPSIS
 --------

--- a/doc/flake-ctl-podman-load.rst
+++ b/doc/flake-ctl-podman-load.rst
@@ -1,10 +1,10 @@
-FLAKE-CTL-LOAD(8)
-=================
+FLAKE-CTL-PODMAN-LOAD(8)
+========================
 
 NAME
 ----
 
-**flake-ctl load** - Load container to local registry
+**flake-ctl podman load** - Load container to local registry
 
 SYNOPSIS
 --------

--- a/doc/flake-ctl-podman-pull.rst
+++ b/doc/flake-ctl-podman-pull.rst
@@ -1,10 +1,10 @@
-FLAKE-CTL-PULL(8)
-=================
+FLAKE-CTL-PODMAN-PULL(8)
+========================
 
 NAME
 ----
 
-**flake-ctl pull** - Fetch container from registry
+**flake-ctl podman pull** - Fetch container from registry
 
 SYNOPSIS
 --------

--- a/doc/flake-ctl-podman-register.rst
+++ b/doc/flake-ctl-podman-register.rst
@@ -1,10 +1,10 @@
-FLAKE-CTL-REGISTER(8)
-=====================
+FLAKE-CTL-PODMAN-REGISTER(8)
+============================
 
 NAME
 ----
 
-**flake-ctl register** - Register container application
+**flake-ctl podman register** - Register container application
 
 SYNOPSIS
 --------

--- a/doc/flake-ctl-podman-remove.rst
+++ b/doc/flake-ctl-podman-remove.rst
@@ -1,10 +1,10 @@
-FLAKE-CTL-REMOVE(8)
-===================
+FLAKE-CTL-PODMAN-REMOVE(8)
+==========================
 
 NAME
 ----
 
-**flake-ctl remove** - Remove application registration and/or entire container
+**flake-ctl podman remove** - Remove application registration and/or entire container
 
 SYNOPSIS
 --------

--- a/flake-ctl/Cargo.toml
+++ b/flake-ctl/Cargo.toml
@@ -19,3 +19,8 @@ env_logger = { version = "0.9.0" }
 glob = { version = "0.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = { version = "0.8" }
+reqwest = { version = "0.11", features = ["stream"] }
+futures-util = { version = "0.3.14" }
+indicatif = { version = "0.15.0" }
+tokio = { version = "1", features = ["full"] }
+tempfile = { version = "3.4.0" }

--- a/flake-ctl/src/cli.rs
+++ b/flake-ctl/src/cli.rs
@@ -40,8 +40,39 @@ pub enum Commands {
         #[clap(subcommand)]
         command: Podman,
     },
+    Firecracker {
+        #[clap(subcommand)]
+        command: Firecracker,
+    },
     /// List registered flake applications
     List {
+    }
+}
+
+#[derive(Subcommand)]
+pub enum Firecracker {
+    /// Pull image
+    #[clap(
+        group(
+            ArgGroup::new("pull")
+                .required(false).args(&["force"])
+        ),
+    )]
+    Pull {
+        /// Image name used as local identifier
+        #[clap(long)]
+        name: String,
+
+        /// Firecracker image built by KIWI as kis image type
+        /// to pull into local image store
+        #[clap(long)]
+        kis_image: String,
+
+        /// Force pulling the image even if it already exists
+        /// This will wipe existing data for the provided
+        /// identifier
+        #[clap(long)]
+        force: bool,
     }
 }
 

--- a/flake-ctl/src/defaults.rs
+++ b/flake-ctl/src/defaults.rs
@@ -33,3 +33,11 @@ pub const PODMAN_PATH:&str =
     "/usr/bin/podman";
 pub const FLAKE_TEMPLATE_CONTAINER:&str =
     "/etc/flakes/container-flake.yaml";
+pub const FIRECRACKER_IMAGES_DIR:&str =
+    "/var/lib/firecracker/images";
+pub const FIRECRACKER_INITRD_NAME:&str =
+    "initrd";
+pub const FIRECRACKER_KERNEL_NAME:&str =
+    "kernel";
+pub const FIRECRACKER_ROOTFS_NAME:&str =
+    "rootfs";

--- a/flake-ctl/src/fetch.rs
+++ b/flake-ctl/src/fetch.rs
@@ -1,0 +1,109 @@
+// This file is part of flake-pilot
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+use std::io::{Error, ErrorKind};
+use std::cmp::min;
+use std::fs::File;
+use std::io::Write;
+use indicatif::{ProgressBar, ProgressStyle};
+use futures_util::StreamExt;
+
+pub async fn fetch_file(
+    response: reqwest::Response, filepath: &String
+) -> Result<(), Box<dyn std::error::Error>> {
+    /*!
+    Download file from response
+    !*/
+    let url = &format!("{}", response.url());
+    let total_size = response
+        .content_length()
+        .ok_or(format!("Failed to get content length from '{}'", url))?;
+    let progress = ProgressBar::new(total_size);
+
+    progress.set_style(ProgressStyle::default_bar()
+        .template(
+            &format!(
+                "{}\n{} [{}] [{}] {}/{} ({}, {})",
+                "{msg}",
+                "{spinner:.green}",
+                "{elapsed_precise}",
+                "{wide_bar:.cyan/blue}",
+                "{bytes}",
+                "{total_bytes}",
+                "{bytes_per_sec}",
+                "{eta}"
+            )
+        )
+        .progress_chars("#>-"));
+    progress.set_message(&format!("Downloading {}", filepath));
+
+    let mut file = File::create(filepath)?;
+    let mut downloaded: u64 = 0;
+    let mut stream = response.bytes_stream();
+
+    while let Some(item) = stream.next().await {
+        let chunk = item?;
+        file.write_all(&chunk)?;
+        let new = min(downloaded + (chunk.len() as u64), total_size);
+        downloaded = new;
+        progress.set_position(new);
+    }
+    progress.finish_with_message(
+        &format!("Downloaded {}", filepath)
+    );
+    return Ok(());
+}
+
+pub async fn send_request(
+    url: &String
+) -> Result<reqwest::Response, Box<dyn std::error::Error>> {
+    /*!
+    Send GET request to the specified url and return response object
+    !*/
+    let client = reqwest::Client::builder()
+        .build()?;
+
+    let response = client
+        .get(url)
+        .send()
+        .await?;
+
+    match response.status() {
+        reqwest::StatusCode::BAD_REQUEST => {
+            let request_error = format!(
+                "content-length:{:?} server:{:?}",
+                response.headers().get(reqwest::header::CONTENT_LENGTH),
+                response.headers().get(reqwest::header::SERVER),
+            );
+            return Err(
+                Box::new(Error::new(ErrorKind::InvalidData, request_error))
+            )
+        },
+        status => {
+            let request_status = format!("{}", status);
+            if request_status != "200 OK" {
+                return Err(
+                    Box::new(Error::new(ErrorKind::Other, request_status))
+                )
+            }
+        },
+    }
+    Ok(response)
+}

--- a/flake-ctl/src/firecracker.rs
+++ b/flake-ctl/src/firecracker.rs
@@ -1,0 +1,182 @@
+//
+// Copyright (c) 2022 Elektrobit Automotive GmbH
+//
+// This file is part of flake-pilot
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+use std::ffi::OsStr;
+use std::process::Command;
+use tempfile::tempdir;
+use std::path::Path;
+use crate::defaults;
+use std::fs;
+
+use crate::fetch::{fetch_file, send_request};
+
+pub fn init_toplevel_image_dir(image_dir: &str) -> bool {
+    /*!
+    Create toplevel firecracker image storage directory
+    !*/
+    let mut ok = false;
+    if ! Path::new(&image_dir).exists() {
+        match fs::create_dir_all(&image_dir) {
+            Ok(_) => { ok = true },
+            Err(error) => {
+                error!("Error creating directory {}: {}", image_dir, error);
+            }
+        }
+    } else {
+        ok = true
+    }
+    ok
+}
+
+pub async fn pull_kis_image(name: &String, uri: &String, force: bool) -> i32 {
+    /*!
+    Fetch the data provided in uri and treat it as a KIWI
+    built KIS image type. This means the file behind uri
+    is expected to be a tarball containing the KIS
+    components; rootfs-image, kernel and optional initrd
+    !*/
+    let mut result = 255;
+
+    info!("Fetching KIS image...");
+
+    if ! init_toplevel_image_dir(defaults::FIRECRACKER_IMAGES_DIR) {
+        return result
+    }
+
+    let image_dir = format!("{}/{}", defaults::FIRECRACKER_IMAGES_DIR, name);
+    if force && Path::new(&image_dir).exists() {
+        match fs::remove_dir_all(&image_dir) {
+            Ok(_) => { },
+            Err(error) => {
+                error!("Error removing directory {}: {}", image_dir, error);
+                return result
+            }
+        }
+    }
+    if Path::new(&image_dir).exists() {
+        error!("Image directory '{}' already exists", image_dir);
+        return result
+    }
+    match tempdir() {
+        Ok(tmp_dir) => {
+            let work_dir = tmp_dir.path().join("work")
+                .into_os_string().into_string().unwrap();
+            let kis_tar = tmp_dir.path().join("kis_archive")
+                .into_os_string().into_string().unwrap();
+
+            // Download...
+            match fs::create_dir_all(&work_dir) {
+                Ok(_) => {
+                    match send_request(&uri).await {
+                        Ok(response) => {
+                            result = response.status().as_u16().into();
+                            match fetch_file(response, &kis_tar).await {
+                                Ok(_) => { },
+                                Err(error) => {
+                                    error!("Download failed with: {}", error);
+                                    return result
+                                }
+                            }
+                        },
+                        Err(error) => {
+                            error!(
+                                "Request to '{}' failed with: {}", uri, error
+                            );
+                            return result
+                        }
+                    }
+                },
+                Err(error) => {
+                    error!(
+                        "Error creating work directory {}: {}",
+                        work_dir, error
+                    );
+                    return result
+                }
+            }
+
+            // Unpack and Rename...
+            info!("Unpacking...");
+            let mut tar = Command::new("tar");
+            tar.arg("-C").arg(&work_dir)
+               .arg("-xf").arg(&kis_tar);
+            match tar.status() {
+                Ok(status) => {
+                    result = status.code().unwrap();
+                },
+                Err(error) => {
+                    error!("Failed to execute tar: {:?}", error);
+                    return result
+                }
+            }
+            let mut kis_ok = 4;
+            for path in fs::read_dir(&work_dir).unwrap() {
+                let path = path.unwrap().path();
+                let extension = path.extension().unwrap();
+                if extension == OsStr::new("append") {
+                    fs::remove_file(&path).unwrap();
+                    kis_ok -= 1;
+                } else if extension == OsStr::new("md5") {
+                    fs::remove_file(&path).unwrap();
+                    kis_ok -= 1;
+                } else if extension == OsStr::new("initrd") {
+                    fs::rename(&path, format!("{}/{}",
+                        work_dir, defaults::FIRECRACKER_INITRD_NAME
+                    )).unwrap();
+                    // optional
+                } else if extension == OsStr::new("kernel") {
+                    fs::rename(&path, format!("{}/{}",
+                        work_dir, defaults::FIRECRACKER_KERNEL_NAME
+                    )).unwrap();
+                    kis_ok -= 1;
+                } else {
+                    fs::rename(&path, format!("{}/{}",
+                        work_dir, defaults::FIRECRACKER_ROOTFS_NAME
+                    )).unwrap();
+                    kis_ok -= 1;
+                }
+            }
+            if kis_ok != 0 {
+                error!("Not a KIWI kis type image");
+                return result
+            }
+
+            // Move to final firecracker image store
+            match fs::rename(&work_dir, &image_dir) {
+                Ok(_) => { },
+                Err(error) => {
+                    error!(
+                        "Failed to rename {} -> {}: {:?}",
+                        work_dir, image_dir, error
+                    );
+                    return result
+                }
+            }
+        },
+        Err(error) => {
+            error!("Failed to create tempdir: {}", error);
+            return result
+        }
+    }
+    result
+}

--- a/package/flake-pilot.spec
+++ b/package/flake-pilot.spec
@@ -143,6 +143,7 @@ mkdir -p %{buildroot}/overlayroot
 
 %files -n flake-pilot-firecracker
 %dir /overlayroot
+%doc /usr/share/man/man8/flake-ctl-firecracker-pull.8.gz
 /usr/bin/firecracker-service
 
 %files -n flake-pilot-firecracker-guestvm-tools


### PR DESCRIPTION
Added support for flake-ctl firecracker pull
    
Added the pull command for the firecracker engine to download and register remote firecracker images into a local storage location below /var/lib/firecracker/images.

This Fixes #83