### PR TITLE
Do not compress sci binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ build: man
 	cd podman-pilot && cargo build -v --release && upx --best --lzma target/release/podman-pilot
 	cd flake-ctl && cargo build -v --release && upx --best --lzma target/release/flake-ctl
 	cd firecracker-pilot/firecracker-service/service && cargo build -v --release && upx --best --lzma target/release/firecracker-service
-	cd firecracker-pilot/guestvm-tools/sci && cargo build -v --release && upx --best --lzma target/release/sci
+	cd firecracker-pilot/guestvm-tools/sci && cargo build -v --release
 	cd firecracker-pilot && cargo build -v --release && upx --best --lzma target/release/firecracker-pilot
 
 clean:

--- a/firecracker-pilot/guestvm-tools/sci/src/main.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/main.rs
@@ -57,6 +57,11 @@ fn main() {
     let mut do_exec = false;
     let mut ok = true;
 
+    // print user space env
+    for (key, value) in env::vars() {
+        debug(&format!("{}: {}", key, value));
+    }
+
     // parse commandline from run environment variable
     match env::var("run").ok() {
         Some(call_cmd) => {
@@ -71,8 +76,7 @@ fn main() {
             }
         },
         None => {
-            debug("No run=... cmdline parameter specified");
-            ok = false
+            panic!("No run=... cmdline parameter in env");
         }
     }
 


### PR DESCRIPTION
When used without an initrd it's not possible for the kernel to run the binary if it was upx compressed. For further details also let sci print the user env in debug mode