### PR TITLE
Added dracut-netstart package for firecracker

### DIFF
--- a/firecracker-pilot/dracut/etc/dracut.conf.d/extramodules.conf
+++ b/firecracker-pilot/dracut/etc/dracut.conf.d/extramodules.conf
@@ -1,0 +1,1 @@
+add_dracutmodules+=" netstart "

--- a/firecracker-pilot/dracut/usr/lib/dracut/modules.d/80netstart/module-setup.sh
+++ b/firecracker-pilot/dracut/usr/lib/dracut/modules.d/80netstart/module-setup.sh
@@ -1,0 +1,14 @@
+declare moddir=${moddir}
+
+check() {
+    return 255
+}
+
+depends() {
+    echo network systemd-networkd systemd-resolved
+    return 0
+}
+
+install() {
+    inst_hook pre-pivot 80 "$moddir/netstart.sh"
+}

--- a/firecracker-pilot/dracut/usr/lib/dracut/modules.d/80netstart/netstart.sh
+++ b/firecracker-pilot/dracut/usr/lib/dracut/modules.d/80netstart/netstart.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Start systemd network and resolver inside of the initrd such
+# that we don't require systemd in the main system which allows
+# non systemd PID 1 processes like sci do gain network access
+#
+# For network configuration see the ip= setup from man dracut.cmdline
+#
+# shellcheck shell=bash
+systemctl restart network
+systemctl restart systemd-resolved

--- a/package/flake-pilot.spec
+++ b/package/flake-pilot.spec
@@ -111,6 +111,21 @@ Requires:       qemu-img
 Launcher and service tools for KVM VM based applications
 through firecracker
 
+%package -n flake-pilot-firecracker-dracut-netstart
+Summary:        Dracut Module Network Startup
+Group:          System/Management
+%if 0%{?suse_version}
+Requires:       systemd-network
+%else
+Requires:       systemd
+%endif
+
+%description -n flake-pilot-firecracker-dracut-netstart
+Start systemd network and resolver inside of the initrd such
+that the network setup persists after switch_root if there
+is no systemd process called but sci as simple command
+execution interface
+
 %package -n flake-pilot-firecracker-guestvm-tools
 Summary:        FireCracker guest VM tools
 Group:          System/Management
@@ -146,6 +161,13 @@ chmod 777 %{buildroot}/var/lib/firecracker/images
 mkdir -p %{buildroot}/var/lib/firecracker/storage
 chmod 777 %{buildroot}/var/lib/firecracker/storage
 
+mkdir -p %{buildroot}/etc/dracut.conf.d
+mkdir -p %{buildroot}/usr/lib/dracut/modules.d/80netstart
+cp -a firecracker-pilot/dracut/usr/lib/dracut/modules.d/80netstart/* \
+    %{buildroot}/usr/lib/dracut/modules.d/80netstart
+install -m 644 firecracker-pilot/dracut/etc/dracut.conf.d/extramodules.conf \
+    %{buildroot}/etc/dracut.conf.d/extramodules.conf
+
 %files
 %defattr(-,root,root)
 %dir /usr/share/flakes
@@ -178,6 +200,14 @@ chmod 777 %{buildroot}/var/lib/firecracker/storage
 /usr/bin/firecracker-pilot
 %doc /usr/share/man/man8/firecracker-service.8.gz
 %doc /usr/share/man/man8/firecracker-pilot.8.gz
+
+%files -n flake-pilot-firecracker-dracut-netstart
+%dir /usr/lib/dracut
+%dir /usr/lib/dracut/modules.d
+%dir /usr/lib/dracut/modules.d/80netstart
+%dir /etc/dracut.conf.d
+/usr/lib/dracut/modules.d/80netstart
+/etc/dracut.conf.d/extramodules.conf
 
 %files -n flake-pilot-firecracker-guestvm-tools
 %dir /overlayroot


### PR DESCRIPTION
The new package flake-pilot-firecracker-dracut-netstart supports users with building firecracker images that supports networking using systemd-networkd and systemd-resolved activated and persistent inside of the initrd. 

This is related to Issue #76