### PR TITLE
Support pulling image from components

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 3. [Quick Start OCI containers](#oci)
     1. [Use Cases](#usecases)
 4. [Quick Start FireCracker VMs](#fire)
-    1. [Networking](#networking)
+    1. [Use FireCracker VM image from components](#components)
+    2. [Networking](#networking)
 5. [Application Setup](#setup)
 
 ## Introduction <a name="introduction"/>
@@ -106,21 +107,23 @@ Open Build Service project was created: https://build.opensuse.org/package/show/
 Feel free to browse through the project and have some fun testing. There
 is a short description in each package how to use them.
 
-**_NOTE:_** Key to success is also the ability to build the individual containers
-and VM images. This is achieved by using the [KIWI](https://github.com/OSInside/kiwi)
-appliance builder which is supported by the Open Build Service backend
-and allows to build all the images in a nice way.
+**_NOTE:_** Key to success is also the ability to build the
+individual containers and VM images. This is achieved by using
+the [KIWI](https://github.com/OSInside/kiwi) appliance builder which is
+supported by the Open Build Service backend and allows to build all the
+images in a maintainable way.
 
 ## Quick Start FireCracker VMs <a name="fire"/>
 
-Using containers to isolate applications from the host system is a common approach.
-The limitation comes on the level of the kernel. Each container shares the kernel
-with the host and if applications requires to run privileged, requires direct access
-to device nodes or kernel interfaces like the device mapper, a deeper level of
-isolation might be needed. At this point full virtual system instances running its
-own kernel, optional initrd and processes inside provides a solution. The price
-to pay is on the performance side but projects like KVM and FireCracker offers
-a nice concept to run virtual machines accelerated through KVM as competitive
+Using containers to isolate applications from the host system is a common
+approach. The limitation comes on the level of the kernel. Each container
+shares the kernel with the host and if applications requires to run
+privileged, requires direct access to device nodes or kernel interfaces
+like the device mapper, a deeper level of isolation might be needed.
+At this point full virtual system instances running its own kernel, optional
+initrd and processes inside provides a solution. The price to pay is on
+the performance side but projects like KVM and FireCracker offers a nice
+concept to run virtual machines accelerated through KVM as competitive
 alternative to containers. Thus flake-pilot also implements support for the
 firecracker engine.
 
@@ -129,18 +132,21 @@ Start an application as virtual machine (VM) instance as follows:
 1. Pull a firecracker compatible VM
 
    ```bash 
-   flake-ctl firecracker pull --name leap --kis-image https://download.opensuse.org/repositories/home:/marcus.schaefer:/delta_containers/images/firecracker-basesystem.x86_64.tar.xz
+   flake-ctl firecracker pull --name leap \
+       --kis-image https://download.opensuse.org/repositories/home:/marcus.schaefer:/delta_containers/images/firecracker-basesystem.x86_64.tar.xz
    ```
 
 2. Register the ```mybash``` application
   
    ```bash
-   flake-ctl firecracker register --vm leap --app /usr/bin/mybash --target /bin/bash --overlay-size 20g
+   flake-ctl firecracker register --vm leap \
+       --app /usr/bin/mybash --target /bin/bash --overlay-size 20GiB
    ```
 
-   This registers an app named ```mybash``` to the system. Once called a firecracker VM based on
-   the pulled ```leap``` image is started and the ```/bin/bash``` program is called inside of
-   the VM instance. In addition some write space of 20GB is added to the instance
+   This registers an app named ```mybash``` to the system. Once called a
+   firecracker VM based on the pulled ```leap``` image is started and
+   the ```/bin/bash``` program is called inside of the VM instance.
+   In addition some write space of 20GB is added to the instance
 
 3. Launch the application
 
@@ -151,6 +157,40 @@ Start an application as virtual machine (VM) instance as follows:
    ```
 
    Drops you into a bash shell inside of the VM
+
+### Use FireCracker VM image from components <a name="components"/>
+
+In the quickstart for FireCracker a special image type called ```kis-image```
+was used. This image type is specific to the KIWI appliance builder and
+it provides the required components to boot up a FireCracker VM in one
+archive. However, it's also possible to pull a FireCracker VM image from
+its single components. Mandatory components are the kernel image and the
+rootfs image, whereas the initrd is optional. The FireCracker project
+itself provides its images in single components and you can use them
+as follows:
+
+1. Pull a firecracker compatible VM
+
+   ```bash
+   flake-ctl firecracker pull --name firecore \
+       --rootfs https://s3.amazonaws.com/spec.ccfc.min/ci-artifacts/disks/x86_64/ubuntu-18.04.ext4 \
+       --kernel https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin
+    ```
+
+2. Register the ```fireshell``` application
+
+   ```bash
+   flake-ctl firecracker register \
+       --app /usr/bin/fireshell --target /bin/bash --vm firecore --no-net
+   ```
+
+3. Launch the application
+
+   To run ```fireshell``` just call for example:
+
+   ```bash
+   fireshell -c "'ls -l'"
+   ```
 
 ### Networking <a name="networking"/>
 

--- a/doc/firecracker-pilot.rst
+++ b/doc/firecracker-pilot.rst
@@ -75,6 +75,8 @@ can be set for the firecracker engine:
             - "console=ttyS0"
             - "root=/dev/vda"
             - "acpi=off"
+            - "rd.neednet=1"
+            - "ip=dhcp"
             - "quiet"
           mem_size_mib: 4096
           vcpu_count: 2
@@ -83,7 +85,7 @@ can be set for the firecracker engine:
           # Size of the VM overlay
           # If specified a new ext2 overlay filesystem image of the
           # specified size will be created and attached to the VM
-          overlay_size: 20g
+          overlay_size: 20GiB
 
           # Path to rootfs image done by app registration
           rootfs_image_path: /var/lib/firecracker/images/NAME/rootfs

--- a/doc/flake-ctl-firecracker-pull.rst
+++ b/doc/flake-ctl-firecracker-pull.rst
@@ -11,13 +11,16 @@ SYNOPSIS
 
 .. code:: bash
 
-   USAGE:
-       flake-ctl firecracker pull [OPTIONS] --name <NAME> --kis-image <KIS_IMAGE>
+    USAGE:
+        flake-ctl firecracker pull [OPTIONS] --name <NAME> <--kis-image <KIS_IMAGE>|--rootfs <ROOTFS>|--kernel <KERNEL>>
 
-   OPTIONS:
-       --force
-       --kis-image <KIS_IMAGE>
-       --name <NAME>
+    OPTIONS:
+        --force
+        --initrd <INITRD>
+        --kernel <KERNEL>
+        --kis-image <KIS_IMAGE>
+        --name <NAME>
+        --rootfs <ROOTFS>
 
 DESCRIPTION
 -----------
@@ -48,6 +51,14 @@ OPTIONS
   Force pulling the image even if it already exists This will wipe
   existing data for the provided identifier
 
+--initrd <INITRD>
+
+  Single initrd image to pull into local image store
+
+--kernel <KERNEL>
+
+  Single kernel image to pull into local image store
+
 --kis-image <KIS_IMAGE>
 
   Firecracker image built by KIWI as kis image type to pull
@@ -59,6 +70,10 @@ OPTIONS
 
   Image name used as local identifier
 
+--rootfs <ROOTFS>
+
+  Single rootfs image to pull into local image store
+
 EXAMPLE
 -------
 
@@ -66,6 +81,10 @@ EXAMPLE
 
    $ flake-ctl firecracker pull --name myImage --kis-image \
        https://download.opensuse.org/repositories/home:/marcus.schaefer:/delta_containers/images/firecracker-basesystem.x86_64.tar.xz
+
+   $ flake-ctl firecracker pull --name firecore \
+       --rootfs https://s3.amazonaws.com/spec.ccfc.min/ci-artifacts/disks/x86_64/ubuntu-18.04.ext4 \
+       --kernel https://s3.amazonaws.com/spec.ccfc.min/img/quickstart_guide/x86_64/kernels/vmlinux.bin
 
 AUTHOR
 ------

--- a/doc/flake-ctl-firecracker-register.rst
+++ b/doc/flake-ctl-firecracker-register.rst
@@ -17,6 +17,7 @@ SYNOPSIS
 
    OPTIONS:
        --app <APP>
+       --no-net
        --overlay-size <OVERLAY_SIZE>
        --run-as <RUN_AS>
        --target <TARGET>
@@ -46,6 +47,10 @@ OPTIONS
   An absolute path to the application on the host. If not specified via
   the target option, the application will be called with that path inside
   of the VM
+
+--no-net
+
+  Disable networking
 
 --overlay-size <OVERLAY_SIZE>
 

--- a/firecracker-pilot/guestvm-tools/sci/src/main.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/main.rs
@@ -111,16 +111,6 @@ fn main() {
                     debug(&format!("Loading overlay module failed: {}", error));
                 }
             }
-            if ! Path::new("/overlayroot").exists() {
-                match fs::create_dir_all("/overlayroot") {
-                    Ok(_) => { },
-                    Err(error) => {
-                        debug(&format!(
-                            "Error creating directory /overlayroot: {}",error
-                        ));
-                    }
-                }
-            }
             debug(&format!("Mounting overlayfs RW({})", overlay.as_str()));
             match Mount::builder()
                 .fstype("ext2").mount(overlay.as_str(), "/overlayroot")

--- a/flake-ctl/src/app.rs
+++ b/flake-ctl/src/app.rs
@@ -155,7 +155,8 @@ pub fn create_vm_config(
     app: Option<&String>,
     target: Option<&String>,
     run_as: Option<&String>,
-    overlay_size: Option<&String>
+    overlay_size: Option<&String>,
+    no_net: bool
 ) -> bool {
     /*!
     Create app configuration for the firecracker engine.
@@ -182,7 +183,8 @@ pub fn create_vm_config(
         &target_app_path,
         &host_app_path,
         run_as,
-        overlay_size
+        overlay_size,
+        no_net
     ) {
         Ok(_) => { result = true },
         Err(error) => {

--- a/flake-ctl/src/cli.rs
+++ b/flake-ctl/src/cli.rs
@@ -105,6 +105,12 @@ pub enum Firecracker {
         force: bool,
     },
     /// Register VM application
+    #[clap(
+        group(
+            ArgGroup::new("register")
+                .required(false).args(&["no-net"])
+        )
+    )]
     Register {
         /// A virtual machine name. The name must match with a
         /// name in the local firecracker registry
@@ -133,6 +139,10 @@ pub enum Firecracker {
         /// Optional suffixes: KiB/MiB/GiB/TiB (1024) or KB/MB/GB/TB (1000)
         #[clap(long)]
         overlay_size: Option<String>,
+
+        /// Disable networking
+        #[clap(long)]
+        no_net: bool
     },
     /// Remove application registration or entire VM
     #[clap(group(

--- a/flake-ctl/src/cli.rs
+++ b/flake-ctl/src/cli.rs
@@ -57,6 +57,24 @@ pub enum Firecracker {
             ArgGroup::new("pull")
                 .required(false).args(&["force"])
         ),
+        group(
+            ArgGroup::new("pullkis")
+                .required(false).args(&["kis-image"])
+                .conflicts_with("rootfs")
+                .conflicts_with("kernel")
+                .conflicts_with("initrd")
+        ),
+        group(
+            ArgGroup::new("pullrootfs")
+                .required(false).args(&["rootfs", "kernel"])
+                .multiple(true)
+                .conflicts_with("kis-image")
+        ),
+        group(
+            ArgGroup::new("action")
+                .required(true).args(&["kis-image", "rootfs", "kernel"])
+                .multiple(true)
+        ),
     )]
     Pull {
         /// Image name used as local identifier
@@ -66,7 +84,19 @@ pub enum Firecracker {
         /// Firecracker image built by KIWI as kis image type
         /// to pull into local image store
         #[clap(long)]
-        kis_image: String,
+        kis_image: Option<String>,
+
+        /// Single rootfs image to pull into local image store
+        #[clap(long, requires = "kernel")]
+        rootfs: Option<String>,
+
+        /// Single kernel image to pull into local image store
+        #[clap(long, requires = "rootfs")]
+        kernel: Option<String>,
+
+        /// Single initrd image to pull into local image store
+        #[clap(long)]
+        initrd: Option<String>,
 
         /// Force pulling the image even if it already exists
         /// This will wipe existing data for the provided

--- a/flake-ctl/src/defaults.rs
+++ b/flake-ctl/src/defaults.rs
@@ -45,3 +45,5 @@ pub const FIRECRACKER_KERNEL_NAME:&str =
     "kernel";
 pub const FIRECRACKER_ROOTFS_NAME:&str =
     "rootfs";
+pub const FIRECRACKER_SCI:&str =
+    "/usr/lib/flake-pilot/sci";

--- a/flake-ctl/src/firecracker.rs
+++ b/flake-ctl/src/firecracker.rs
@@ -25,9 +25,11 @@ use std::ffi::OsStr;
 use std::process::Command;
 use tempfile::tempdir;
 use std::path::Path;
+use std::borrow::Cow;
+use std::fs;
+
 use crate::defaults;
 use crate::{app, app_config};
-use std::fs;
 
 use crate::fetch::{fetch_file, send_request};
 
@@ -49,7 +51,115 @@ pub fn init_toplevel_image_dir(image_dir: &str) -> bool {
     ok
 }
 
-pub async fn pull_kis_image(name: &String, uri: &String, force: bool) -> i32 {
+pub async fn pull_component_image(
+    name: &String, rootfs_uri: Option<&String>, kernel_uri: Option<&String>,
+    initrd_uri: Option<&String>, force: bool
+) -> i32 {
+    /*!
+    Fetch components image consisting out of rootfs, kernel and
+    optional initrd.
+    !*/
+    let mut result = 255;
+    let image_dir = format!("{}/{}", defaults::FIRECRACKER_IMAGES_DIR, name);
+    struct Component<'a> {
+        uri: String,
+        file: Cow<'a, str>
+    }
+    info!("Fetching Component image...");
+    if ! pull_new(&name, force) {
+        return result
+    }
+    match tempdir() {
+        Ok(tmp_dir) => {
+            let mut download_files: Vec<Component> = Vec::new();
+            let rootfs_file = tmp_dir.path().join("rootfs")
+                .into_os_string().into_string().unwrap();
+            let kernel_file = tmp_dir.path().join("kernel")
+                .into_os_string().into_string().unwrap();
+            let initrd_file = tmp_dir.path().join("initrd")
+                .into_os_string().into_string().unwrap();
+            download_files.push(
+                Component {
+                    uri: rootfs_uri.unwrap().to_string(),
+                    file: Cow::Borrowed(&rootfs_file),
+                }
+            );
+            download_files.push(
+                Component {
+                    uri: kernel_uri.unwrap().to_string(),
+                    file: Cow::Borrowed(&kernel_file),
+                }
+            );
+            if ! initrd_uri.is_none() {
+                download_files.push(
+                    Component {
+                        uri: initrd_uri.unwrap().to_string(),
+                        file: Cow::Borrowed(&initrd_file),
+                    }
+                );
+            }
+            // Download...
+            for component in download_files {
+                match send_request(&component.uri).await {
+                    Ok(response) => {
+                        result = response.status().as_u16().into();
+                        match fetch_file(
+                            response, &component.file.into_owned()).await
+                        {
+                            Ok(_) => { },
+                            Err(error) => {
+                                error!(
+                                    "Download failed with: {}", error
+                                );
+                                return result
+                            }
+                        }
+                    },
+                    Err(error) => {
+                        error!(
+                            "Request to '{}' failed with: {}",
+                            component.uri, error
+                        );
+                        return result
+                    }
+                }
+            }
+            // Check for sci and add it to rootfs image if not present
+            let tmp_dir_path = tmp_dir.path().display().to_string();
+            if mount_fs_image(&rootfs_file, &tmp_dir_path, "root") {
+                let sci_in_image = format!(
+                    "{}/{}", tmp_dir_path, "/usr/sbin/sci"
+                );
+                if ! Path::new(&sci_in_image).exists() {
+                    info!("Copying sci to rootfs...");
+                    copy(&defaults::FIRECRACKER_SCI, &sci_in_image, "root");
+                }
+                umount(&tmp_dir_path, "root");
+            }
+
+            // Move to final firecracker image store
+            match fs::rename(&tmp_dir.path(), &image_dir) {
+                Ok(_) => { },
+                Err(error) => {
+                    error!(
+                        "Failed to rename {} -> {}: {:?}",
+                        tmp_dir.path().display(), image_dir, error
+                    );
+                    return result
+                }
+            }
+        },
+        Err(error) => {
+            error!("Failed to create tempdir: {}", error);
+            return result
+        }
+    }
+    result
+}
+
+pub async fn pull_kis_image(
+    name: &String, uri: Option<&String>, force: bool
+) -> i32 {
     /*!
     Fetch the data provided in uri and treat it as a KIWI
     built KIS image type. This means the file behind uri
@@ -57,27 +167,14 @@ pub async fn pull_kis_image(name: &String, uri: &String, force: bool) -> i32 {
     components; rootfs-image, kernel and optional initrd
     !*/
     let mut result = 255;
+    let image_dir = format!("{}/{}", defaults::FIRECRACKER_IMAGES_DIR, name);
 
     info!("Fetching KIS image...");
 
-    if ! init_toplevel_image_dir(defaults::FIRECRACKER_IMAGES_DIR) {
+    if ! pull_new(&name, force) {
         return result
     }
 
-    let image_dir = format!("{}/{}", defaults::FIRECRACKER_IMAGES_DIR, name);
-    if force && Path::new(&image_dir).exists() {
-        match fs::remove_dir_all(&image_dir) {
-            Ok(_) => { },
-            Err(error) => {
-                error!("Error removing directory {}: {}", image_dir, error);
-                return result
-            }
-        }
-    }
-    if Path::new(&image_dir).exists() {
-        error!("Image directory '{}' already exists", image_dir);
-        return result
-    }
     match tempdir() {
         Ok(tmp_dir) => {
             let work_dir = tmp_dir.path().join("work")
@@ -88,7 +185,7 @@ pub async fn pull_kis_image(name: &String, uri: &String, force: bool) -> i32 {
             // Download...
             match fs::create_dir_all(&work_dir) {
                 Ok(_) => {
-                    match send_request(&uri).await {
+                    match send_request(&uri.unwrap()).await {
                         Ok(response) => {
                             result = response.status().as_u16().into();
                             match fetch_file(response, &kis_tar).await {
@@ -101,7 +198,8 @@ pub async fn pull_kis_image(name: &String, uri: &String, force: bool) -> i32 {
                         },
                         Err(error) => {
                             error!(
-                                "Request to '{}' failed with: {}", uri, error
+                                "Request to '{}' failed with: {}",
+                                uri.unwrap(), error
                             );
                             return result
                         }
@@ -180,6 +278,90 @@ pub async fn pull_kis_image(name: &String, uri: &String, force: bool) -> i32 {
         }
     }
     result
+}
+
+pub fn copy(source: &str, target: &String, user: &str) -> bool {
+    /*!
+    Copy file via sudo
+    !*/
+    let mut call = Command::new("sudo");
+    if ! user.is_empty() {
+        call.arg("--user").arg(user);
+    }
+    call.arg("cp").arg(&source).arg(&target);
+    match call.status() {
+        Ok(_) => { },
+        Err(error) => {
+            error!("Failed to cp: {} -> {}: {:?}", source, target, error);
+            return false
+        }
+    }
+    true
+}
+
+pub fn mount_fs_image(
+    fs_name: &str, mount_point: &String, user: &str
+) -> bool {
+    /*!
+    Mount filesystem image
+    !*/
+    let mut call = Command::new("sudo");
+    if ! user.is_empty() {
+        call.arg("--user").arg(user);
+    }
+    call.arg("mount").arg(&fs_name).arg(&mount_point);
+    match call.status() {
+        Ok(_) => { },
+        Err(error) => {
+            error!("Failed to execute mount: {:?}", error);
+            return false
+        }
+    }
+    true
+}
+
+pub fn umount(mount_point: &str, user: &str) -> bool {
+    /*!
+    Umount given mount_point
+    !*/
+    let mut call = Command::new("sudo");
+    if ! user.is_empty() {
+        call.arg("--user").arg(user);
+    }
+    call.arg("umount").arg(&mount_point);
+    match call.status() {
+        Ok(_) => { },
+        Err(error) => {
+            error!("Failed to execute mount: {:?}", error);
+            return false
+        }
+    }
+    true
+}
+
+
+pub fn pull_new(name: &String, force: bool) -> bool {
+    /*!
+    Initialize new pull
+    !*/
+    if ! init_toplevel_image_dir(defaults::FIRECRACKER_IMAGES_DIR) {
+        return false
+    }
+    let image_dir = format!("{}/{}", defaults::FIRECRACKER_IMAGES_DIR, name);
+    if force && Path::new(&image_dir).exists() {
+        match fs::remove_dir_all(&image_dir) {
+            Ok(_) => { },
+            Err(error) => {
+                error!("Error removing directory {}: {}", image_dir, error);
+                return false
+            }
+        }
+    }
+    if Path::new(&image_dir).exists() {
+        error!("Image directory '{}' already exists", image_dir);
+        return false
+    }
+    true
 }
 
 pub fn purge_vm(vm: &str) {

--- a/flake-ctl/src/main.rs
+++ b/flake-ctl/src/main.rs
@@ -59,12 +59,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         cli::Commands::Firecracker { command } => {
             match &command {
                 // pull
-                cli::Firecracker::Pull { name, kis_image, force } => {
-                    exit(
-                        firecracker::pull_kis_image(
-                            name, kis_image, *force
-                        ).await
-                    );
+                cli::Firecracker::Pull {
+                    name, kis_image, rootfs, kernel, initrd, force
+                } => {
+                    if ! kis_image.is_none() {
+                        exit(
+                            firecracker::pull_kis_image(
+                                name, kis_image.as_ref(), *force
+                            ).await
+                        );
+                    } else {
+                        exit(
+                            firecracker::pull_component_image(
+                                name, rootfs.as_ref(), kernel.as_ref(),
+                                initrd.as_ref(), *force
+                            ).await
+                        );
+                    }
                 },
                 // register
                 cli::Firecracker::Register {

--- a/flake-ctl/src/main.rs
+++ b/flake-ctl/src/main.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
                 // register
                 cli::Firecracker::Register {
-                    vm, app, target, run_as, overlay_size
+                    vm, app, target, run_as, overlay_size, no_net
                 } => {
                     if app::init(Some(app)) {
                         let mut ok = app::register(
@@ -92,7 +92,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 Some(app),
                                 target.as_ref(),
                                 run_as.as_ref(),
-                                overlay_size.as_ref()
+                                overlay_size.as_ref(),
+                                *no_net
                             );
                         }
                         if ! ok {


### PR DESCRIPTION
So far pulling a firecracker image was limited to the KIWI kis image type. With this commit it's also possible to pull an image from it's components; rootfs, kernel and optional initrd. This allows for example to make use of the firecracker hosted CI images or any other rootfs image in combination with some kernel/initrd. During the pull of such an image there is also a check for the sci binary inside of the rootfs. If it does not exist it gets added to the rootfs such that the firecracker-pilot can work with it. This Fixes #99