### PR TITLE
Make sure to create /overlayroot

### DIFF
--- a/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
@@ -24,9 +24,9 @@
 use std::env;
 
 pub const SWITCH_ROOT: &str =
-    "/usr/sbin/switch_root";
+    "/sbin/switch_root";
 pub const PIVOT_ROOT: &str =
-    "/usr/sbin/pivot_root";
+    "/sbin/pivot_root";
 pub const OVERLAY_ROOT: &str =
     "/overlayroot/rootfs";
 pub const OVERLAY_UPPER: &str =
@@ -34,7 +34,7 @@ pub const OVERLAY_UPPER: &str =
 pub const OVERLAY_WORK: &str =
     "/overlayroot/rootfs_work";
 pub const PROBE_MODULE: &str =
-    "/usr/sbin/modprobe";
+    "/sbin/modprobe";
 pub const SYSTEMD_NETWORK_RESOLV_CONF: &str =
     "/run/systemd/resolve/resolv.conf";
 

--- a/firecracker-pilot/guestvm-tools/sci/src/main.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/main.rs
@@ -111,6 +111,16 @@ fn main() {
                     debug(&format!("Loading overlay module failed: {}", error));
                 }
             }
+            if ! Path::new("/overlayroot").exists() {
+                match fs::create_dir_all("/overlayroot") {
+                    Ok(_) => { },
+                    Err(error) => {
+                        debug(&format!(
+                            "Error creating directory /overlayroot: {}",error
+                        ));
+                    }
+                }
+            }
             debug(&format!("Mounting overlayfs RW({})", overlay.as_str()));
             match Mount::builder()
                 .fstype("ext2").mount(overlay.as_str(), "/overlayroot")


### PR DESCRIPTION
When using arbitrary rootfs images it might happen that there is no /overlayroot mountpoint which we use in the pilot to setup an overlay. In addition search for tools like switch_root in the former location /sbin to stay backward compatible with linux versions prior the /usr/sbin move. Newer linux versions still maintains symlinks from /sbin to /usr/sbin for compat reasons.