### PR TITLE
Fixed setup of firecracker registry layout

### DIFF
--- a/flake-ctl/src/defaults.rs
+++ b/flake-ctl/src/defaults.rs
@@ -37,6 +37,8 @@ pub const FLAKE_TEMPLATE_CONTAINER:&str =
     "/etc/flakes/container-flake.yaml";
 pub const FLAKE_TEMPLATE_FIRECRACKER:&str =
     "/etc/flakes/firecracker-flake.yaml";
+pub const FIRECRACKER_REGISTRY_DIR:&str =
+    "/var/lib/firecracker";
 pub const FIRECRACKER_IMAGES_DIR:&str =
     "/var/lib/firecracker/images";
 pub const FIRECRACKER_INITRD_NAME:&str =


### PR DESCRIPTION
For firecracker the layout looks like the following:

/var/lib/firecracker/
    ├── images
    └── storage

The code in flake-ctl setting it up only cared for the images subdirectory and did not allow /var/lib/firecracker to be a symlink location