### PR TITLE
FIX for wrongly handled CID in json configuration

### DIFF
--- a/firecracker-pilot/src/defaults.rs
+++ b/firecracker-pilot/src/defaults.rs
@@ -32,6 +32,7 @@ pub const FIRECRACKER_FLAKE_DIR: &str =
 pub const FIRECRACKER_VMID_DIR: &str =
     "/tmp/flakes";
 pub const GC_THRESHOLD: i32 = 20;
+pub const VM_CID: u32 = 3;
 
 pub fn is_debug() -> bool {
     let debug_set;

--- a/firecracker-pilot/src/firecracker.rs
+++ b/firecracker-pilot/src/firecracker.rs
@@ -548,7 +548,7 @@ pub fn create_firecracker_config(
                         format!("tap-{}", get_meta_name(&program_name));
 
                     // set vsock name
-                    firecracker_config.vsock.guest_cid = process::id();
+                    firecracker_config.vsock.guest_cid = defaults::VM_CID;
                     firecracker_config.vsock.uds_path =
                         format!("/run/sci_cmd_{}.sock", process::id());
 


### PR DESCRIPTION
The CID in VM shall always be equall 3 as the connection generated by firecracker is vsock less connection, means static cid bound on vm to the unix domain socket bound on host