### PR TITLE
Add resume support to firecracker app registration

### DIFF
--- a/doc/firecracker-pilot.rst
+++ b/doc/firecracker-pilot.rst
@@ -68,6 +68,13 @@ can be set for the firecracker engine:
         # file /etc/sudoers
         runas: root
 
+        # Resume the VM from previous execution.
+        # If the VM is still running, the app will be
+        # executed inside of this VM instance.
+        #
+        # Default: false
+        resume: true|false
+
         firecracker:
           # Currently fixed settings through app registration
           boot_args:

--- a/doc/flake-ctl-firecracker-register.rst
+++ b/doc/flake-ctl-firecracker-register.rst
@@ -18,6 +18,7 @@ SYNOPSIS
    OPTIONS:
        --app <APP>
        --no-net
+       --resume
        --overlay-size <OVERLAY_SIZE>
        --run-as <RUN_AS>
        --target <TARGET>
@@ -56,6 +57,11 @@ OPTIONS
 
   Size of overlay write space in bytes. Optional suffixes are:
   KiB/MiB/GiB/TiB (1024) or KB/MB/GB/TB (1000)
+
+--resume
+
+  Resume the VM from previous execution. If the VM is still running,
+  the app will be executed inside of this VM instance
 
 --run-as <RUN_AS>
 

--- a/firecracker-pilot/src/firecracker.rs
+++ b/firecracker-pilot/src/firecracker.rs
@@ -115,6 +115,13 @@ pub fn create(
         # file /etc/sudoers
         runas: root
 
+        # Resume the VM from previous execution.
+        # If the VM is still running, the app will be
+        # executed inside of this VM instance.
+        #
+        # Default: false
+        resume: true|false
+
         firecracker:
           # Currently fixed settings through app registration
           boot_args:

--- a/flake-ctl/src/app.rs
+++ b/flake-ctl/src/app.rs
@@ -156,7 +156,8 @@ pub fn create_vm_config(
     target: Option<&String>,
     run_as: Option<&String>,
     overlay_size: Option<&String>,
-    no_net: bool
+    no_net: bool,
+    resume: bool
 ) -> bool {
     /*!
     Create app configuration for the firecracker engine.
@@ -184,7 +185,8 @@ pub fn create_vm_config(
         &host_app_path,
         run_as,
         overlay_size,
-        no_net
+        no_net,
+        resume
     ) {
         Ok(_) => { result = true },
         Err(error) => {

--- a/flake-ctl/src/app_config.rs
+++ b/flake-ctl/src/app_config.rs
@@ -174,7 +174,8 @@ impl AppConfig {
         host_app_path: &String,
         run_as: Option<&String>,
         overlay_size: Option<&String>,
-        no_net: bool
+        no_net: bool,
+        resume: bool
     ) -> Result<(), GenericError> {
         /*!
         save stores an AppConfig to the given file
@@ -193,6 +194,10 @@ impl AppConfig {
         vm_config.target_app_path = target_app_path.to_string();
         vm_config.host_app_path = host_app_path.to_string();
 
+        if resume {
+            vm_config.runtime.as_mut().unwrap()
+                .resume = Some(resume);
+        }
         if ! run_as.is_none() {
             vm_config.runtime.as_mut().unwrap()
                 .runas = Some(run_as.unwrap().to_string());
@@ -256,6 +261,13 @@ impl AppConfig {
                 }
             }
             firecracker_section.boot_args = Some(boot_args);
+        }
+
+        if resume {
+            let firecracker_section = vm_config.runtime.as_mut().unwrap()
+                .firecracker.as_mut().unwrap();
+            firecracker_section.boot_args.as_mut().unwrap()
+                .push(format!("sci_resume=1"));
         }
 
         let config = std::fs::OpenOptions::new()

--- a/flake-ctl/src/cli.rs
+++ b/flake-ctl/src/cli.rs
@@ -135,6 +135,12 @@ pub enum Firecracker {
         #[clap(long)]
         run_as: Option<String>,
 
+        /// Resume the VM from previous execution.
+        /// If the VM is still running, the app will be
+        /// executed inside of this VM instance.
+        #[clap(long)]
+        resume: bool,
+
         /// Size of overlay write space in bytes.
         /// Optional suffixes: KiB/MiB/GiB/TiB (1024) or KB/MB/GB/TB (1000)
         #[clap(long)]

--- a/flake-ctl/src/main.rs
+++ b/flake-ctl/src/main.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
                 // register
                 cli::Firecracker::Register {
-                    vm, app, target, run_as, overlay_size, no_net
+                    vm, app, target, run_as, overlay_size, no_net, resume
                 } => {
                     if app::init(Some(app)) {
                         let mut ok = app::register(
@@ -93,7 +93,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 target.as_ref(),
                                 run_as.as_ref(),
                                 overlay_size.as_ref(),
-                                *no_net
+                                *no_net,
+                                *resume
                             );
                         }
                         if ! ok {


### PR DESCRIPTION
Write sci_resume=1 to the boot cmdline arguments if --resume is set at app registration for the firecracker pilot. This is related to Issue #87