### PR TITLE
Refactor sci for resume mode

### DIFF
--- a/firecracker-pilot/Cargo.toml
+++ b/firecracker-pilot/Cargo.toml
@@ -22,3 +22,4 @@ env_logger = { version = "0.9" }
 tempfile = { version = "3.4" }
 spinoff = { version = "0.7" }
 ubyte = { version = "0.10" }
+rand = { version = "0.8" }

--- a/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
@@ -41,6 +41,8 @@ pub const VM_QUIT: &str =
     "sci_quit";
 pub const VHOST_TRANSPORT: &str =
     "vmw_vsock_virtio_transport";
+pub const SOCAT: &str =
+    "/usr/bin/socat";
 pub const VM_PORT: u32 = 
     52;
 pub const GUEST_CID: u32 =

--- a/firecracker-pilot/src/defaults.rs
+++ b/firecracker-pilot/src/defaults.rs
@@ -33,6 +33,14 @@ pub const FIRECRACKER_VMID_DIR: &str =
     "/tmp/flakes";
 pub const GC_THRESHOLD: i32 = 20;
 pub const VM_CID: u32 = 3;
+pub const VM_PORT: u32 =
+    52;
+pub const SOCAT: &str =
+    "/usr/bin/socat";
+pub const RETRIES: u32 =
+    5;
+pub const VM_WAIT_TIMEOUT_MSEC: u64 =
+    1000;
 
 pub fn is_debug() -> bool {
     let debug_set;


### PR DESCRIPTION
The former implementation used the vsock channel to read the command, call it in a child and send the output back through the vsock channel. This works until the command is not interactive. With this refactor I propose a different way to handle the command execution.

start vsock listener on VM_PORT, wait for command(s) in a loop. A received command turns into a
socat process using a pseudo terminal (pts) and output that can be retrieved by simply connecting
to the EXEC_PORT

Example:

```
sudo socat UNIX-CONNECT:/run/sci_cmd_XXX.sock -
CONNECT 52
ls -l
```

```
sudo socat UNIX-CONNECT:/run/sci_cmd_XXX.sock -
CONNECT 42
```


The above procedure needs to be implemeted as
part of the firecracker-pilot resume code

Thoughts ?