### PR TITLE
Disable loop feature in sys_mount

### DIFF
--- a/firecracker-pilot/guestvm-tools/sci/Cargo.toml
+++ b/firecracker-pilot/guestvm-tools/sci/Cargo.toml
@@ -7,9 +7,9 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-env_logger = "0.10.0"
-log = "0.4"
-sys-mount = "2.0.2"
-system_shutdown = "4.0.1"
-shell-words = "1.1.0"
-vsock = "0.3.0"
+env_logger = { version = "0.10" }
+log = { version = "0.4" }
+sys-mount = { version = "2.0", default-features = false, features = [] }
+system_shutdown = { version = "4.0" }
+shell-words = { version = "1.1" }
+vsock = { version = "0.3" }

--- a/package/flake-pilot.spec
+++ b/package/flake-pilot.spec
@@ -41,7 +41,7 @@ Requires:       sudo
 Requires:       rsync
 Requires:       tar
 BuildRequires:  pandoc
-%if 0%{?fedora} || 0%{?suse_version}
+%if 0%{?suse_version}
 BuildRequires:  rust
 BuildRequires:  cargo
 BuildRequires:  upx
@@ -139,7 +139,7 @@ Guest VM tools to help with firecracker workloads
 %build
 # This is a hack and related to the issue explained here:
 # https://github.com/rust-lang/rust/issues/99382
-%if 0%{?fedora} || 0%{?suse_version}
+%if 0%{?suse_version} && 0%{?suse_version} < 1650
 sudo bash %{SOURCE2}
 %endif
 


### PR DESCRIPTION
By default sys_mount supports loop devices. In sci. We don't use them and for kernel 6.x the code does
not compile anymore and fails with: ```enum_(unnamed_at_/usr/include/linux/loop_h_16_1)" is not a valid Ident```

Newer distros e.g TW, Lobster, rawhide .... uses kernel 6.x and there the rust loop feature in sys_mout no longer
compiles. As it's a code path we never use, the disabling of the feature only has positive effects, less dependencies,
smaller binary size, compiles on kernel 6.x based distros
