### PR TITLE
Move flake metadata dir to persistent location

### DIFF
--- a/firecracker-pilot/src/defaults.rs
+++ b/firecracker-pilot/src/defaults.rs
@@ -30,7 +30,7 @@ pub const FIRECRACKER_TEMPLATE:&str =
 pub const FIRECRACKER_FLAKE_DIR: &str =
     "/usr/share/flakes";
 pub const FIRECRACKER_VMID_DIR: &str =
-    "/tmp/flakes";
+    "/var/lib/firecracker/storage/tmp/flakes";
 pub const GC_THRESHOLD: i32 = 20;
 pub const VM_CID: u32 = 3;
 pub const VM_PORT: u32 =

--- a/podman-pilot/src/defaults.rs
+++ b/podman-pilot/src/defaults.rs
@@ -24,7 +24,7 @@
 use std::env;
 
 pub const CONTAINER_FLAKE_DIR: &str = "/usr/share/flakes";
-pub const CONTAINER_CID_DIR: &str = "/tmp/flakes";
+pub const CONTAINER_CID_DIR: &str = "/var/lib/containers/storage/tmp/flakes";
 pub const GC_THRESHOLD: i32 = 20;
 pub const HOST_DEPENDENCIES: &str = "removed";
 


### PR DESCRIPTION
flakes metadata was written to /tmp, but this is a non persistent storage area (tmpfs). For resume type instances it is required to keep the information to allow resume a stopped container. This Fixes #119