### PR TITLE
Add firecracker include provisioning

### DIFF
--- a/doc/flake-ctl-firecracker-register.rst
+++ b/doc/flake-ctl-firecracker-register.rst
@@ -17,6 +17,7 @@ SYNOPSIS
 
    OPTIONS:
        --app <APP>
+       --include-tar <INCLUDE_TAR>...
        --no-net
        --resume
        --overlay-size <OVERLAY_SIZE>
@@ -48,6 +49,11 @@ OPTIONS
   An absolute path to the application on the host. If not specified via
   the target option, the application will be called with that path inside
   of the VM
+
+--include-tar <INCLUDE_TAR>...
+
+  Name of a tar file to be included on top of the VM instance.
+  This option can be specified multiple times
 
 --no-net
 

--- a/firecracker-pilot/src/defaults.rs
+++ b/firecracker-pilot/src/defaults.rs
@@ -23,6 +23,16 @@
 //
 use std::env;
 
+pub const IMAGE_ROOT: &str =
+    "image";
+pub const IMAGE_OVERLAY: &str =
+    "overlayroot";
+pub const OVERLAY_ROOT: &str =
+    "overlayroot/rootfs";
+pub const OVERLAY_UPPER: &str =
+    "overlayroot/rootfs_upper";
+pub const OVERLAY_WORK: &str =
+    "overlayroot/rootfs_work";
 pub const FIRECRACKER_OVERLAY_DIR:&str =
     "/var/lib/firecracker/storage";
 pub const FIRECRACKER_TEMPLATE:&str =

--- a/flake-ctl/src/app.rs
+++ b/flake-ctl/src/app.rs
@@ -157,7 +157,8 @@ pub fn create_vm_config(
     run_as: Option<&String>,
     overlay_size: Option<&String>,
     no_net: bool,
-    resume: bool
+    resume: bool,
+    includes_tar: Option<Vec<String>>,
 ) -> bool {
     /*!
     Create app configuration for the firecracker engine.
@@ -186,7 +187,8 @@ pub fn create_vm_config(
         run_as,
         overlay_size,
         no_net,
-        resume
+        resume,
+        includes_tar,
     ) {
         Ok(_) => { result = true },
         Err(error) => {

--- a/flake-ctl/src/app_config.rs
+++ b/flake-ctl/src/app_config.rs
@@ -175,7 +175,8 @@ impl AppConfig {
         run_as: Option<&String>,
         overlay_size: Option<&String>,
         no_net: bool,
-        resume: bool
+        resume: bool,
+        includes_tar: Option<Vec<String>>,
     ) -> Result<(), GenericError> {
         /*!
         save stores an AppConfig to the given file
@@ -201,6 +202,11 @@ impl AppConfig {
         if ! run_as.is_none() {
             vm_config.runtime.as_mut().unwrap()
                 .runas = Some(run_as.unwrap().to_string());
+        }
+        if ! includes_tar.is_none() {
+            yaml_config.include.tar = Some(
+                includes_tar.as_ref().unwrap().to_vec()
+            );
         }
         if ! overlay_size.is_none() {
             vm_config.runtime.as_mut().unwrap()

--- a/flake-ctl/src/cli.rs
+++ b/flake-ctl/src/cli.rs
@@ -148,7 +148,13 @@ pub enum Firecracker {
 
         /// Disable networking
         #[clap(long)]
-        no_net: bool
+        no_net: bool,
+
+        /// Name of a tar file to be included on top of
+        /// the VM instance. This option can be
+        /// specified multiple times.
+        #[clap(long, multiple = true, requires = "overlay-size")]
+        include_tar: Option<Vec<String>>,
     },
     /// Remove application registration or entire VM
     #[clap(group(

--- a/flake-ctl/src/main.rs
+++ b/flake-ctl/src/main.rs
@@ -79,7 +79,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
                 // register
                 cli::Firecracker::Register {
-                    vm, app, target, run_as, overlay_size, no_net, resume
+                    vm, app, target, run_as, overlay_size, no_net, resume,
+                    include_tar
                 } => {
                     if app::init(Some(app)) {
                         let mut ok = app::register(
@@ -94,7 +95,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 run_as.as_ref(),
                                 overlay_size.as_ref(),
                                 *no_net,
-                                *resume
+                                *resume,
+                                include_tar.as_ref().cloned()
                             );
                         }
                         if ! ok {

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -630,6 +630,7 @@ pub fn sync_includes(
             match call.output() {
                 Ok(output) => {
                     debug(&String::from_utf8_lossy(&output.stdout).to_string());
+                    debug(&String::from_utf8_lossy(&output.stderr).to_string());
                     status_code = output.status.code().unwrap();
                 },
                 Err(error) => {


### PR DESCRIPTION
This commit implements reading of the flake include section for the firecracker pilot. With the include tar support it's possible to provision any arbitrary data into the VM instance prior launch. For firecracker the include feature requires the use of an overlay. This Fixes #95