### PR TITLE
Increase max retries on resume type VM

### DIFF
--- a/firecracker-pilot/src/defaults.rs
+++ b/firecracker-pilot/src/defaults.rs
@@ -38,7 +38,7 @@ pub const VM_PORT: u32 =
 pub const SOCAT: &str =
     "/usr/bin/socat";
 pub const RETRIES: u32 =
-    5;
+    20;
 pub const VM_WAIT_TIMEOUT_MSEC: u64 =
     1000;
 


### PR DESCRIPTION
When connecting to a resume type VM for the first time, the wait time was not long enough. Increasing the retry count will solve this issue. If after this delay the VM is still not responsive on the vsock it's likely an issue on the VM startup itself and ok to close. This Fixes #122