### PR TITLE
Clarify on license

### DIFF
--- a/helper/update_changelog.py
+++ b/helper/update_changelog.py
@@ -1,4 +1,27 @@
 #!/usr/bin/python3
+#
+# Copyright (c) 2023 Marcus Schäfer
+#
+# This file is part of flake-pilot
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
 """
 usage: update_changelog (--since=<reference_file>|--file=<reference_file>)
             [--utc]


### PR DESCRIPTION
Add missing license information to update_changelog.py license is MIT in alignment with the overall flake-pilot license. The license setting is in agreement with the only copyright holder of the software which is the person of this signed commit. This Fixes #125