### PR TITLE
Use rst2man instead of pandoc to render man pages

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,6 +1,6 @@
 man:
 	for man in $(shell find -name "*.rst" | sed -e "s@.rst@@"); do \
-		pandoc --standalone --to man $$man.rst -o $$man.8 ;\
+		rst2man $$man.rst $$man.8 ;\
 	done
 
 clean:

--- a/doc/firecracker-pilot.rst
+++ b/doc/firecracker-pilot.rst
@@ -19,7 +19,7 @@ at the time an application is registered via **flake-ctl firecracker register**.
 
 This means firecracker-pilot is the actual binary called with any application
 registration. If the registered application is requested as
-:file:`/usr/bin/myapp` there will be a symlink pointing to:
+`/usr/bin/myapp` there will be a symlink pointing to:
 
 .. code:: bash
 
@@ -28,9 +28,9 @@ registration. If the registered application is requested as
 Consequently calling **myapp** will effectively call **firecracker-pilot**.
 firecracker-pilot now reads the calling program basename, which is **myapp**
 and looks up all the registration metadata stored in
-:file:`/usr/share/flakes`
+`/usr/share/flakes`
 
-Below :file:`/usr/share/flakes` each application is registered
+Below `/usr/share/flakes` each application is registered
 with the following layout:
 
 .. code:: bash
@@ -41,10 +41,10 @@ with the following layout:
        └── myapp.yaml
 
 All metadata information read by **firecracker-pilot** uses the YAML
-markup. The main configuration :file:`myapp.yaml` is read first
-and can be optionally extended with further :file:`*.yaml` files
-below the :file:`myapp.d` directory. All files in the
-:file:`myapp.d` directory will be read in alpha sort order.
+markup. The main configuration `myapp.yaml` is read first
+and can be optionally extended with further `*.yaml` files
+below the `myapp.d` directory. All files in the
+`myapp.d` directory will be read in alpha sort order.
 Redundant information will always overwrite the former one.
 Thus the last setting in the sequence wins.
 

--- a/doc/flake-ctl-firecracker-register.rst
+++ b/doc/flake-ctl-firecracker-register.rst
@@ -31,8 +31,8 @@ DESCRIPTION
 Register the given application to run inside of the specified firecracker
 virtual machine. The registration process is two fold:
 
-1. Create the application symlink pointing to :file:`/usr/bin/firecracker-pilot`
-2. Create the application default configuration below :file:`/usr/share/flakes`.
+1. Create the application symlink pointing to `/usr/bin/firecracker-pilot`
+2. Create the application default configuration below `/usr/share/flakes`.
    Each application registered is called a **flake**
 
 On successful completion the registered *--app* name can be called

--- a/doc/flake-ctl-firecracker-remove.rst
+++ b/doc/flake-ctl-firecracker-remove.rst
@@ -26,8 +26,8 @@ Remove registration(s). The command operates in two modes:
 1. Remove an application registration provided via **--app**
 
    In this mode the command deletes the specified application if it
-   is a link pointing to :file:`/usr/bin/firecracker-pilot`. It then also
-   deletes the application configuration from :file:`/usr/share/flakes`
+   is a link pointing to `/usr/bin/firecracker-pilot`. It then also
+   deletes the application configuration from `/usr/share/flakes`
 
 2. Remove a VM including all its registered applications via **--vm**
 

--- a/doc/flake-ctl-podman-register.rst
+++ b/doc/flake-ctl-podman-register.rst
@@ -33,8 +33,8 @@ DESCRIPTION
 Register the given application to run inside of the specified container.
 The registration process is two fold:
 
-1. Create the application symlink pointing to :file:`/usr/bin/podman-pilot`
-2. Create the application default configuration below :file:`/usr/share/flakes`.
+1. Create the application symlink pointing to `/usr/bin/podman-pilot`
+2. Create the application default configuration below `/usr/share/flakes`.
    Each application registered is called a **flake**
 
 On successful completion the registered *--app* name can be called

--- a/doc/flake-ctl-podman-remove.rst
+++ b/doc/flake-ctl-podman-remove.rst
@@ -26,8 +26,8 @@ Remove registration(s). The command operates in two modes:
 1. Remove an application registration provided via **--app**
 
    In this mode the command deletes the specified application if it
-   is a link pointing to :file:`/usr/bin/podman-pilot`. It then also
-   deletes the application configuration from :file:`/usr/share/flakes`
+   is a link pointing to `/usr/bin/podman-pilot`. It then also
+   deletes the application configuration from `/usr/share/flakes`
 
 2. Remove a container including all its registered applications via **--container**
 

--- a/doc/podman-pilot.rst
+++ b/doc/podman-pilot.rst
@@ -19,7 +19,7 @@ at the time an application is registered via **flake-ctl podman register**.
 
 This means podman-pilot is the actual binary called with any application
 registration. If the registered application is requested as
-:file:`/usr/bin/myapp` there will be a symlink pointing to:
+`/usr/bin/myapp` there will be a symlink pointing to:
 
 .. code:: bash
 
@@ -28,9 +28,9 @@ registration. If the registered application is requested as
 Consequently calling **myapp** will effectively call **podman-pilot**.
 podman-pilot now reads the calling program basename, which is **myapp**
 and looks up all the registration metadata stored in
-:file:`/usr/share/flakes`
+`/usr/share/flakes`
 
-Below :file:`/usr/share/flakes` each application is registered
+Below `/usr/share/flakes` each application is registered
 with the following layout:
 
 .. code:: bash
@@ -41,10 +41,10 @@ with the following layout:
        └── myapp.yaml
 
 All metadata information read by **podman-pilot** uses the YAML
-markup. The main configuration :file:`myapp.yaml` is read first
-and can be optionally extended with further :file:`*.yaml` files
-below the :file:`myapp.d` directory. All files in the
-:file:`myapp.d` directory will be read in alpha sort order.
+markup. The main configuration `myapp.yaml` is read first
+and can be optionally extended with further `*.yaml` files
+below the `myapp.d` directory. All files in the
+`myapp.d` directory will be read in alpha sort order.
 Redundant information will always overwrite the former one.
 Thus the last setting in the sequence wins.
 

--- a/package/flake-pilot.spec
+++ b/package/flake-pilot.spec
@@ -40,7 +40,7 @@ Requires:       golang-github-containers-common
 Requires:       sudo
 Requires:       rsync
 Requires:       tar
-BuildRequires:  pandoc
+BuildRequires:  python3-docutils
 %if 0%{?suse_version}
 BuildRequires:  rust
 BuildRequires:  cargo
@@ -48,6 +48,7 @@ BuildRequires:  upx
 BuildRequires:  openssl-devel
 BuildRequires:  glibc-devel-static
 BuildRequires:  kiwi-settings
+BuildRequires:  python3-Pygments
 %endif
 %if 0%{?debian} || 0%{?ubuntu}
 BuildRequires:  rust-all
@@ -55,6 +56,7 @@ BuildRequires:  upx-ucl
 BuildRequires:  libssl-dev
 BuildRequires:  openssl
 BuildRequires:  pkg-config
+BuildRequires:  python3-pygments
 %endif
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 


### PR DESCRIPTION
pandoc is pretty big and adds a lot of haskel lib requirements rst2man just requires python3-docutils and is more lightweight