### PR TITLE
Replace adhoc yaml with serde

### DIFF
--- a/podman-pilot/Cargo.toml
+++ b/podman-pilot/Cargo.toml
@@ -15,8 +15,10 @@ license = "MIT"
 
 [dependencies]
 which = { version = "4.2.5" }
-yaml-rust = { version = "0.4" }
 log = { version = "0.4" }
 env_logger = { version = "0.9.0" }
 tempfile = { version = "3.4.0" }
 spinoff = { version = "0.7.0" }
+serde = { version = "1.0.173", features=["derive"]}
+serde_yaml = "0.9.24"
+lazy_static = "1.4.0"

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -1,0 +1,119 @@
+use lazy_static::lazy_static;
+use serde::Deserialize;
+use std::{env, path::PathBuf, fs};
+
+use crate::defaults;
+
+lazy_static! {
+    static ref CONFIG: Config<'static> = load_config();
+}
+
+/// Returns the config singleton
+/// 
+/// Will initialize the config on first call and return the cached version afterwards
+pub fn config() -> &'static Config<'static> {
+    &CONFIG
+}
+
+fn get_base_path() -> PathBuf {
+    which::which(env::args().next().expect("Arg 0 must be present")).expect("Symlink should exist")
+}
+
+fn load_config() -> Config<'static> {
+    let base_path = get_base_path();
+    let base_path  = base_path.file_name().unwrap().to_str().unwrap();
+    let content = fs::read_to_string(format!("{}/{}.yaml", defaults::CONTAINER_FLAKE_DIR, base_path));
+    
+    // Leak the data to make it static
+    // Safety: This does not cause a reocurring memory leak since `load_config` is only called once
+    let content = Box::leak(content.unwrap().into_boxed_str());
+    serde_yaml::from_str(content).unwrap()
+}
+
+#[derive(Deserialize)]
+pub struct Config<'a> {
+    #[serde(borrow)]
+    pub container: ContainerSection<'a>,
+    pub tar: Vec<&'a str>
+}
+
+impl<'a> Config<'a> {
+    pub fn is_delta_container(&self) -> bool {
+        self.container.base_container.is_some()
+    }
+
+    pub fn runtime(&self) -> RuntimeSection {
+        self.container.runtime.as_ref().cloned().unwrap_or_default()
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ContainerSection<'a> {
+    /// Mandatory registration setup
+    /// Name of the container in the local registry
+    pub name: &'a str,
+
+    /// Path of the program to call inside of the container (target)
+    pub target_app_path: Option<&'a str>,
+
+    /// Path of the program to register on the host
+    pub host_app_path: &'a str,
+
+    /// Optional base container to use with a delta 'container: name'
+    ///
+    /// If specified the given 'container: name' is expected to be
+    /// an overlay for the specified base_container. podman-pilot
+    /// combines the 'container: name' with the base_container into
+    /// one overlay and starts the result as a container instance
+    ///
+    /// Default: not_specified
+    pub base_container: Option<&'a str>,
+
+    /// Optional additional container layers on top of the
+    /// specified base container
+    #[serde(default)]
+    pub layers: Vec<&'a str>,
+
+    /// Optional registration setup
+    /// Container runtime parameters
+    #[serde(default)]
+    pub runtime: Option<RuntimeSection<'a>>,
+}
+
+#[derive(Deserialize, Default, Clone)]
+pub struct RuntimeSection<'a> {
+    /// Run the container engine as a user other than the
+    /// default target user root. The user may be either
+    /// a user name or a numeric user-ID (UID) prefixed
+    /// with the ‘#’ character (e.g. #0 for UID 0). The call
+    /// of the container engine is performed by sudo.
+    /// The behavior of sudo can be controlled via the
+    /// file /etc/sudoers
+    #[serde(borrow)]
+    pub runas: &'a str,
+
+    /// Resume the container from previous execution.
+    ///
+    /// If the container is still running, the app will be
+    /// executed inside of this container instance.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub resume: bool,
+
+    /// Attach to the container if still running, rather than
+    /// executing the app again. Only makes sense for interactive
+    /// sessions like a shell running as app in the container.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub attach: bool,
+
+    /// Caller arguments for the podman engine in the format:
+    /// - PODMAN_OPTION_NAME_AND_OPTIONAL_VALUE
+    ///
+    /// For details on podman options please consult the
+    /// podman documentation.
+    #[serde(default)]
+    pub podman: Vec<&'a str>,
+}

--- a/podman-pilot/src/main.rs
+++ b/podman-pilot/src/main.rs
@@ -32,19 +32,18 @@ use env_logger::Env;
 pub mod app_path;
 pub mod podman;
 pub mod defaults;
+pub mod config;
 
 fn main() {
     setup_logger();
 
     let program_path = app_path::program_abs_path();
     let program_name = app_path::basename(&program_path);
-    let runtime_config = app_path::program_config(&program_name);
 
-    let container = podman::create(&program_name, &runtime_config);
+    let container = podman::create(&program_name);
     let cid = &container[0];
     podman::start(
         &program_name,
-        &runtime_config,
         cid
     );
 }


### PR DESCRIPTION
first part of #128 

Includes only podman config, will copy the approach for firecracker and/or create generic version for all back ends if approved

Adds lazy_static for config initialization, can be removed if rust version is bumped to one that includes [OnceCell](https://doc.rust-lang.org/stable/std/cell/struct.OnceCell.html)