### PR TITLE
Replace adhoc yaml with serde

### DIFF
--- a/podman-pilot/Cargo.toml
+++ b/podman-pilot/Cargo.toml
@@ -20,3 +20,6 @@ log = { version = "0.4" }
 env_logger = { version = "0.9.0" }
 tempfile = { version = "3.4.0" }
 spinoff = { version = "0.7.0" }
+lazy_static = "1.4.0"
+serde = "1.0.175"
+serde_yaml = "0.9.25"

--- a/podman-pilot/Cargo.toml
+++ b/podman-pilot/Cargo.toml
@@ -21,5 +21,5 @@ env_logger = { version = "0.9.0" }
 tempfile = { version = "3.4.0" }
 spinoff = { version = "0.7.0" }
 lazy_static = "1.4.0"
-serde = "1.0.175"
+serde = {version = "1.0.175", features = ["derive"]}
 serde_yaml = "0.9.25"

--- a/podman-pilot/src/app_path.rs
+++ b/podman-pilot/src/app_path.rs
@@ -26,12 +26,6 @@ extern crate yaml_rust;
 use std::env;
 use which::which;
 use std::path::Path;
-use std::process::exit;
-use std::fs;
-use yaml_rust::Yaml;
-use yaml_rust::YamlLoader;
-
-use crate::defaults;
 
 pub fn program_abs_path() -> String {
     /*!
@@ -53,64 +47,4 @@ pub fn basename(program_path: &String) -> String {
         Path::new(program_path).file_name().unwrap().to_str().unwrap()
     );
     program_name
-}
-
-pub fn program_config_file(program_basename: &String) -> String {
-    /*!
-    Provide expected config file path for the given program_basename
-    !*/
-    let config_file = &format!(
-        "{}/{}.yaml", defaults::CONTAINER_FLAKE_DIR, program_basename
-    );
-    config_file.to_string()
-}
-
-pub fn program_config_dir(program_basename: &String) -> String {
-    /*!
-    Provide expected config directory for the given program_basename
-    !*/
-    let config_dir = &format!(
-        "{}/{}.d", defaults::CONTAINER_FLAKE_DIR, program_basename
-    );
-    config_dir.to_string()
-}
-
-pub fn program_config(program_basename: &String) -> Vec<Yaml> {
-    /*!
-    Read container runtime configuration for given program
-
-    CONTAINER_FLAKE_DIR/
-       ├── program_name.d
-       │   └── other.yaml
-       └── program_name.yaml
-
-    Config files below program_name.d are read in alpha sort order
-    and attached to the master program_name.yaml file. The result
-    is send to the Yaml parser
-    !*/
-    let config_file = program_config_file(program_basename);
-    let mut yaml_content: String = fs::read_to_string(
-        &config_file
-    ).unwrap_or_else(|why| {
-        error!("Failed to read: {}: {:?}", config_file, why.kind());
-        exit(1)
-    });
-    let custom_config_dir = program_config_dir(program_basename);
-    if Path::new(&custom_config_dir).exists() {
-        // put dir entries to vector to allow for sorting
-        let mut custom_configs: Vec<_> = fs::read_dir(&custom_config_dir)
-            .unwrap().map(|r| r.unwrap()).collect();
-        custom_configs.sort_by_key(|entry| entry.path());
-        for filename in custom_configs {
-            let config_file = format!("{}", filename.path().display());
-            let add_yaml_content: String = fs::read_to_string(
-                &config_file
-            ).unwrap_or_else(|why| {
-                error!("Failed to read: {}: {:?}", config_file, why.kind());
-                exit(1)
-            });
-            yaml_content.push_str(&add_yaml_content);
-        }
-    }
-    YamlLoader::load_from_str(&yaml_content).unwrap()
 }

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -34,7 +34,8 @@ fn load_config() -> Config<'static> {
 pub struct Config<'a> {
     #[serde(borrow)]
     pub container: ContainerSection<'a>,
-    pub tar: Vec<&'a str>
+    #[serde(borrow)]
+    pub include: IncludeSection<'a>
 }
 
 impl<'a> Config<'a> {
@@ -45,6 +46,20 @@ impl<'a> Config<'a> {
     pub fn runtime(&self) -> RuntimeSection {
         self.container.runtime.as_ref().cloned().unwrap_or_default()
     }
+
+    pub fn layers(&self) -> Vec<&'a str> {
+        self.container.layers.as_ref().cloned().unwrap_or_default()
+    }
+
+    pub fn tars(&self) -> Vec<&'a str> {
+        self.include.tar.as_ref().cloned().unwrap_or_default()
+    }
+}
+
+#[derive(Deserialize)]
+pub struct IncludeSection<'a> {
+    #[serde(borrow)]
+    tar: Option<Vec<&'a str>>
 }
 
 #[derive(Deserialize)]
@@ -72,7 +87,7 @@ pub struct ContainerSection<'a> {
     /// Optional additional container layers on top of the
     /// specified base container
     #[serde(default)]
-    pub layers: Vec<&'a str>,
+    layers: Option<Vec<&'a str>>,
 
     /// Optional registration setup
     /// Container runtime parameters
@@ -90,7 +105,7 @@ pub struct RuntimeSection<'a> {
     /// The behavior of sudo can be controlled via the
     /// file /etc/sudoers
     #[serde(borrow)]
-    pub runas: &'a str,
+    pub runas: Option<&'a str>,
 
     /// Resume the container from previous execution.
     ///
@@ -115,5 +130,5 @@ pub struct RuntimeSection<'a> {
     /// For details on podman options please consult the
     /// podman documentation.
     #[serde(default)]
-    pub podman: Vec<&'a str>,
+    pub podman: Option<Vec<&'a str>>,
 }

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -1,6 +1,5 @@
 use lazy_static::lazy_static;
 use serde::Deserialize;
-use serde_yaml::{Value, from_str, to_string};
 use std::{env, path::PathBuf, fs};
 
 use crate::defaults;

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -24,14 +24,16 @@ fn load_config() -> Config<'static> {
     let base_path  = base_path.file_name().unwrap().to_str().unwrap();
     let base_yaml = fs::read_to_string(format!("{}/{}.yaml", defaults::CONTAINER_FLAKE_DIR, base_path));
 
-    let extra_yamls = fs::read_dir(format!("{}/{}.d", defaults::CONTAINER_FLAKE_DIR, base_path))
+    let mut extra_yamls: Vec<_> = fs::read_dir(format!("{}/{}.d", defaults::CONTAINER_FLAKE_DIR, base_path))
         .into_iter()
         .flatten()
         .flatten()
-        .map(|x| x.path())
-        .flat_map(fs::read_to_string);
+        .map(|x| x.path()).collect();
 
-    let full_yaml: String = base_yaml.into_iter().chain(extra_yamls).collect();
+    extra_yamls.sort();
+        
+
+    let full_yaml: String = base_yaml.into_iter().chain(extra_yamls.into_iter().flat_map(fs::read_to_string)).collect();
     config_from_str(&full_yaml)
 
 }

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -1,0 +1,119 @@
+use lazy_static::lazy_static;
+use serde::Deserialize;
+use std::{env, path::PathBuf, fs};
+
+use crate::defaults;
+
+lazy_static! {
+    static ref CONFIG: Config<'static> = load_config();
+}
+
+/// Returns the config singleton
+/// 
+/// Will initialize the config on first call and return the cached version afterwards
+pub fn config() -> &'static Config<'static> {
+    &CONFIG
+}
+
+fn get_base_path() -> PathBuf {
+    which::which(env::args().next().expect("Arg 0 must be present")).expect("Symlink should exist")
+}
+
+fn load_config() -> Config<'static> {
+    let base_path = get_base_path();
+    let base_path  = base_path.file_name().unwrap().to_str().unwrap();
+    let content = fs::read_to_string(format!("{}/{}.yaml", defaults::CONTAINER_FLAKE_DIR, base_path));
+    
+    // Leak the data to make it static
+    // Safety: This does not cause a reocurring memory leak since `load_config` is only called once
+    let content = Box::leak(content.unwrap().into_boxed_str());
+    serde_yaml::from_str(content).unwrap()
+}
+
+#[derive(Deserialize)]
+pub struct Config<'a> {
+    #[serde(borrow)]
+    pub container: ContainerSection<'a>,
+    pub tar: Vec<&'a str>
+}
+
+impl<'a> Config<'a> {
+    pub fn is_delta_container(&self) -> bool {
+        self.container.base_container.is_some()
+    }
+
+    pub fn runtime(&self) -> RuntimeSection {
+        self.container.runtime.as_ref().cloned().unwrap_or_default()
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ContainerSection<'a> {
+    /// Mandatory registration setup
+    /// Name of the container in the local registry
+    pub name: &'a str,
+
+    /// Path of the program to call inside of the container (target)
+    pub target_app_path: Option<&'a str>,
+
+    /// Path of the program to register on the host
+    pub host_app_path: &'a str,
+
+    /// Optional base container to use with a delta 'container: name'
+    ///
+    /// If specified the given 'container: name' is expected to be
+    /// an overlay for the specified base_container. podman-pilot
+    /// combines the 'container: name' with the base_container into
+    /// one overlay and starts the result as a container instance
+    ///
+    /// Default: not_specified
+    pub base_container: Option<&'a str>,
+
+    /// Optional additional container layers on top of the
+    /// specified base container
+    #[serde(default)]
+    pub layers: Vec<&'a str>,
+
+    /// Optional registration setup
+    /// Container runtime parameters
+    #[serde(default)]
+    pub runtime: Option<RuntimeSection<'a>>,
+}
+
+#[derive(Deserialize, Default, Clone)]
+pub struct RuntimeSection<'a> {
+    /// Run the container engine as a user other than the
+    /// default target user root. The user may be either
+    /// a user name or a numeric user-ID (UID) prefixed
+    /// with the ‘#’ character (e.g. #0 for UID 0). The call
+    /// of the container engine is performed by sudo.
+    /// The behavior of sudo can be controlled via the
+    /// file /etc/sudoers
+    #[serde(borrow)]
+    pub runas: &'a str,
+
+    /// Resume the container from previous execution.
+    ///
+    /// If the container is still running, the app will be
+    /// executed inside of this container instance.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub resume: bool,
+
+    /// Attach to the container if still running, rather than
+    /// executing the app again. Only makes sense for interactive
+    /// sessions like a shell running as app in the container.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub attach: bool,
+
+    /// Caller arguments for the podman engine in the format:
+    /// - PODMAN_OPTION_NAME_AND_OPTIONAL_VALUE
+    ///
+    /// For details on podman options please consult the
+    /// podman documentation.
+    #[serde(default)]
+    pub podman: Vec<&'a str>,
+}

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -39,12 +39,16 @@ fn load_config() -> Config<'static> {
 
 fn config_from_str(input: &str) -> Config<'static> {
     // Parse into a generic YAML to remove duplicate keys
-    let yaml: Value = from_str(input).unwrap();
-    
+
+    let yaml = yaml_rust::YamlLoader::load_from_str(input).unwrap();
+    let yaml = yaml.first().unwrap();
+    let mut buffer = String::new();
+    yaml_rust::YamlEmitter::new(&mut buffer).dump(yaml).unwrap();
+
     // Convert to a String and leak it to make it static
     // Can not use serde_yaml::from_value because of lifetime limitations
     // Safety: This does not cause a reocurring memory leak since `load_config` is only called once
-    let content = Box::leak(to_string(&yaml).unwrap().into_boxed_str());
+    let content = Box::leak(buffer.into_boxed_str());
     
     serde_yaml::from_str(content).unwrap()
 }

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -19,6 +19,15 @@ fn get_base_path() -> PathBuf {
     which::which(env::args().next().expect("Arg 0 must be present")).expect("Symlink should exist")
 }
 
+
+///    Read container runtime configuration for given program
+///    CONTAINER_FLAKE_DIR/
+///       ├── program_name.d
+///       │   └── other.yaml
+///       └── program_name.yaml
+///    Config files below program_name.d are read in alpha sort order
+///    and attached to the master program_name.yaml file. The result
+///    is send to the Yaml parser
 fn load_config() -> Config<'static> {
     let base_path = get_base_path();
     let base_path  = base_path.file_name().unwrap().to_str().unwrap();

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -151,3 +151,35 @@ pub struct RuntimeSection<'a> {
     #[serde(default)]
     pub podman: Option<Vec<&'a str>>,
 }
+
+#[cfg(test)]
+mod test {
+    use super::config_from_str;
+
+    #[test]
+    fn simple_config() {
+        let cfg = config_from_str(
+r#"container:
+ name: JoJo
+ host_app_path: /myapp
+include:
+ tar: ~
+"#);
+        assert_eq!(cfg.container.name, "JoJo");
+    }
+    
+    #[test]
+    fn combine_configs() {
+        let cfg = config_from_str(
+r#"container:
+ name: JoJo
+ host_app_path: /myapp
+include:
+ tar: ~
+container:
+ name: Dio
+ host_app_path: /other
+"#);
+        assert_eq!(cfg.container.name, "Dio");
+    }
+}

--- a/podman-pilot/src/main.rs
+++ b/podman-pilot/src/main.rs
@@ -32,19 +32,18 @@ use env_logger::Env;
 pub mod app_path;
 pub mod podman;
 pub mod defaults;
+pub mod config;
 
 fn main() {
     setup_logger();
 
     let program_path = app_path::program_abs_path();
     let program_name = app_path::basename(&program_path);
-    let runtime_config = app_path::program_config(&program_name);
 
-    let container = podman::create(&program_name, &runtime_config);
+    let container = podman::create(&program_name);
     let cid = &container[0];
     podman::start(
         &program_name,
-        &runtime_config,
         cid
     );
 }

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -159,7 +159,7 @@ pub fn create(
 
     let mut app = Command::new("sudo");
     if let Some(user) = runas {
-        app.arg("--user").arg(&user);
+        app.arg("--user").arg(user);
     }
     app.arg("podman").arg("create")
         .arg("--cidfile").arg(&container_cid_file);

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -22,13 +22,12 @@
 // SOFTWARE.
 //
 use spinoff::{Spinner, spinners, Color};
-use yaml_rust::Yaml;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::process::exit;
 use std::env;
 use std::fs;
-use crate::app_path::program_config_file;
+use crate::config::{RuntimeSection, config};
 use crate::defaults::debug;
 use tempfile::tempfile;
 use std::io::{Write, Read};
@@ -39,7 +38,7 @@ use std::io::SeekFrom;
 use crate::defaults;
 
 pub fn create(
-    program_name: &String, runtime_config: &[Yaml]
+    program_name: &String
 ) -> Vec<String> {
     /*!
     Create container for later execution of program_name.
@@ -130,65 +129,33 @@ pub fn create(
     }
     container_cid_file = format!("{}.cid", container_cid_file);
 
-    let container_section = &runtime_config[0]["container"];
+    let container_section = &config().container;
 
     // check for includes
-    let include_section = &runtime_config[0]["include"];
-    let tar_includes = &include_section["tar"];
-    let has_includes = tar_includes.as_vec().is_some();
+    let tar_includes = &config().tar;
+    let has_includes = !tar_includes.is_empty();
 
     // setup podman container to use
-    if container_section["name"].as_str().is_none() {
-        error!("No 'name' attribute specified in {}",
-            program_config_file(program_name)
-        );
-        exit(1)
-    }
-    let container_name = container_section["name"].as_str().unwrap();
+    let container_name = container_section.name;
 
     // setup base container if specified
-    let container_base_name;
-    let delta_container;
-    if container_section["base_container"].as_str().is_some() {
-        // get base container name
-        container_base_name = container_section["base_container"]
-            .as_str().unwrap();
+    let delta_container = container_section.base_container.is_some();
+    let container_base_name= container_section.base_container.unwrap_or_default();
+
+    if container_section.base_container.is_some() {
         // get additional container layers
-        let layer_section = &container_section["layers"];
-        if layer_section.as_vec().is_some() {
-            for layer in layer_section.as_vec().unwrap() {
-                debug(&format!("Adding layer: [{}]", layer.as_str().unwrap()));
-                layers.push(layer.as_str().unwrap().to_string());
-            }
-        }
-        delta_container = true;
-    } else {
-        container_base_name = "";
-        delta_container = false;
+
+        layers.extend(container_section.layers.iter()
+            .inspect(|layer| debug(&format!("Adding layer: [{layer}]")))
+            .map(|x| (*x).to_owned()));
     }
 
     // setup app command path name to call
-    let target_app_path = get_target_app_path(program_name, runtime_config);
+    let target_app_path = get_target_app_path(program_name);
 
     // get runtime section
-    let runtime_section = &container_section["runtime"];
-
-    // setup container operation mode
-    let mut resume: bool = false;
-    let mut attach: bool = false;
-    let mut runas = String::new();
-
-    if runtime_section.as_hash().is_some() {
-        if ! &runtime_section["resume"].as_bool().is_none() {
-            resume = runtime_section["resume"].as_bool().unwrap();
-        }
-        if ! &runtime_section["attach"].as_bool().is_none() {
-            attach = runtime_section["attach"].as_bool().unwrap();
-        }
-        if ! &runtime_section["runas"].as_str().is_none() {
-            runas.push_str(runtime_section["runas"].as_str().unwrap());
-        }
-    }
+    let RuntimeSection { runas, resume, attach, .. } = config().runtime();
+    let runas = runas.to_owned();
 
     let mut app = Command::new("sudo");
     if ! runas.is_empty() {
@@ -234,20 +201,10 @@ pub fn create(
 
     // create the container with configured runtime arguments
     let mut has_runtime_arguments: bool = false;
-    if runtime_section.as_hash().is_some() {
-        let podman_section = &runtime_section["podman"];
-        if let Some(podman_section) = podman_section.as_vec() {
-            has_runtime_arguments = true;
-            for opt in podman_section {
-                let mut split_opt = opt.as_str().unwrap().splitn(2, ' ');
-                let opt_name = split_opt.next();
-                let opt_value = split_opt.next();
-                app.arg(opt_name.unwrap());
-                if let Some(opt_value) = opt_value {
-                    app.arg(opt_value);
-                }
-            }
-        }
+    if let Some(RuntimeSection { podman, .. }) = &config().container.runtime {
+
+        app.args(podman.iter().flat_map(|x| x.splitn(2, ' ')));
+        has_runtime_arguments = !podman.is_empty();
     }
 
     // setup default runtime arguments if not configured
@@ -359,7 +316,7 @@ pub fn create(
                     if has_includes && provision_ok {
                         debug("Syncing includes...");
                         provision_ok = sync_includes(
-                            &instance_mount_point, runtime_config, &runas
+                            &instance_mount_point, &runas
                         )
                     }
 
@@ -385,19 +342,16 @@ pub fn create(
 }
 
 pub fn start(
-    program_name: &str, runtime_config: &[Yaml], cid: &str
+    program_name: &str, cid: &str
 ) {
     /*!
     Start container with the given container ID
 
     podman-pilot exits with the return code from podman after this function
     !*/
-    let container_section = &runtime_config[0]["container"];
-    let runtime_section = &container_section["runtime"];
 
-    let resume = runtime_section.as_hash().and(runtime_section["resume"].as_bool()).unwrap_or_default();
-    let attach = runtime_section.as_hash().and(runtime_section["attach"].as_bool()).unwrap_or_default();
-    let runas = runtime_section.as_hash().and(runtime_section["runas"].as_str()).unwrap_or_default().to_owned();
+    let RuntimeSection { runas, resume, attach, .. } = config().runtime();
+    let runas = runas.to_owned();
     
     let is_running = container_running(cid, &runas);
 
@@ -406,28 +360,28 @@ pub fn start(
         if attach {
             // 1. Attach to running container
             call_instance(
-                "attach", cid, program_name, runtime_config, &runas
+                "attach", cid, program_name, &runas
             )
         } else {
             // 2. Execute app in running container
             call_instance(
-                "exec", cid, program_name, runtime_config, &runas
+                "exec", cid, program_name, &runas
             )
         }
     } else if resume {
         // 3. Startup resume type container and execute app
         let status_code = call_instance(
-            "start", cid, program_name, runtime_config, &runas
+            "start", cid, program_name, &runas
         );
         if status_code == 0 {
             call_instance(
-                "exec", cid, program_name, runtime_config, &runas
+                "exec", cid, program_name, &runas
             )
         } else { status_code }
     } else {
         // 4. Startup container
         call_instance(
-            "start", cid, program_name, runtime_config, &runas
+            "start", cid, program_name, &runas
         )
     };
 
@@ -435,7 +389,7 @@ pub fn start(
 }
 
 pub fn get_target_app_path(
-    program_name: &str, runtime_config: &[Yaml]
+    program_name: &str
 ) -> String {
     /*!
     setup application command path name
@@ -445,23 +399,20 @@ pub fn get_target_app_path(
     configuration file
     !*/
 
-    runtime_config[0]["container"]["target_app_path"].as_str().unwrap_or(program_name).to_owned()
+    config().container.target_app_path.unwrap_or(program_name).to_owned()
 }
 
 pub fn call_instance(
     action: &str, cid: &str, program_name: &str,
-    runtime_config: &[Yaml], user: &str
+    user: &str
 ) -> i32 {
     /*!
     Call container ID based podman commands
     !*/
     let args: Vec<String> = env::args().collect();
-    let container_section = &runtime_config[0]["container"];
-    let runtime_section = &container_section["runtime"];
-    let mut resume: bool = false;
-    if runtime_section.as_hash().is_some() && ! &runtime_section["resume"].as_bool().is_none() {
-        resume = runtime_section["resume"].as_bool().unwrap();
-    }
+
+    let RuntimeSection { resume, .. } = config().runtime();
+
     let mut call = Command::new("sudo");
     if action == "create" || action == "rm" {
         call.stderr(Stdio::null());
@@ -485,7 +436,7 @@ pub fn call_instance(
     call.arg(cid);
     if action == "exec" {
         call.arg(
-            get_target_app_path(program_name, runtime_config)
+            get_target_app_path(program_name)
         );
         for arg in &args[1..] {
             if ! arg.starts_with('@') {
@@ -573,34 +524,32 @@ pub fn umount_container(
 }
 
 pub fn sync_includes(
-    target: &String, runtime_config: &[Yaml], user: &String
+    target: &String, user: &String
 ) -> bool {
     /*!
     Sync custom include data to target path
     !*/
-    let include_section = &runtime_config[0]["include"];
-    let tar_includes = &include_section["tar"];
+    let tar_includes = &config().tar;
     let mut status_code = 0;
-    if tar_includes.as_vec().is_some() {
-        for tar in tar_includes.as_vec().unwrap() {
-            debug(&format!("Adding tar include: [{}]", tar.as_str().unwrap()));
-            let mut call = Command::new("sudo");
-            if ! user.is_empty() {
-                call.arg("--user").arg(user);
-            }
-            call.arg("tar")
-                .arg("-C").arg(target)
-                .arg("-xf").arg(tar.as_str().unwrap());
-            debug(&format!("{:?}", call.get_args()));
-            match call.output() {
-                Ok(output) => {
-                    debug(&String::from_utf8_lossy(&output.stdout));
-                    debug(&String::from_utf8_lossy(&output.stderr));
-                    status_code = output.status.code().unwrap();
-                },
-                Err(error) => {
-                    panic!("Failed to execute tar: {:?}", error)
-                }
+    
+    for tar in tar_includes {
+        debug(&format!("Adding tar include: [{}]", tar));
+        let mut call = Command::new("sudo");
+        if ! user.is_empty() {
+            call.arg("--user").arg(user);
+        }
+        call.arg("tar")
+            .arg("-C").arg(target)
+            .arg("-xf").arg(tar);
+        debug(&format!("{:?}", call.get_args()));
+        match call.output() {
+            Ok(output) => {
+                debug(&String::from_utf8_lossy(&output.stdout));
+                debug(&String::from_utf8_lossy(&output.stderr));
+                status_code = output.status.code().unwrap();
+            },
+            Err(error) => {
+                panic!("Failed to execute tar: {:?}", error)
             }
         }
     }

--- a/podman-pilot/src/tests.rs
+++ b/podman-pilot/src/tests.rs
@@ -23,18 +23,11 @@
 //
 use crate::app_path::program_abs_path;
 use crate::app_path::basename;
-use crate::app_path::program_config_file;
 
 #[test]
 fn test_program_abs_path() {
     let program_path = program_abs_path();
     assert!(program_path.starts_with('/'));
-}
-
-#[test]
-fn test_program_config_file() {
-    let config_file = program_config_file(&"app".to_string());
-    assert_eq!("/usr/share/flakes/app.yaml", config_file);
 }
 
 #[test]


### PR DESCRIPTION
first part of https://github.com/Elektrobit/flake-pilot/issues/128

Includes only podman config, will copy the approach for firecracker and/or create generic version for all back ends if approved

Adds lazy_static for config initialization, can be removed if rust version is bumped to one that includes [OnceCell](https://doc.rust-lang.org/stable/std/cell/struct.OnceCell.html)