### PR TITLE
Better error handling

### DIFF
--- a/podman-pilot/Cargo.toml
+++ b/podman-pilot/Cargo.toml
@@ -23,3 +23,4 @@ spinoff = { version = "0.7.0" }
 lazy_static = "1.4.0"
 serde = {version = "1.0.175", features = ["derive"]}
 serde_yaml = "0.9.25"
+thiserror = "1.0.44"

--- a/podman-pilot/Cargo.toml
+++ b/podman-pilot/Cargo.toml
@@ -20,3 +20,6 @@ log = { version = "0.4" }
 env_logger = { version = "0.9.0" }
 tempfile = { version = "3.4.0" }
 spinoff = { version = "0.7.0" }
+lazy_static = "1.4.0"
+serde = "1.0.175"
+serde_yaml = "0.9.25"

--- a/podman-pilot/Cargo.toml
+++ b/podman-pilot/Cargo.toml
@@ -21,5 +21,5 @@ env_logger = { version = "0.9.0" }
 tempfile = { version = "3.4.0" }
 spinoff = { version = "0.7.0" }
 lazy_static = "1.4.0"
-serde = "1.0.175"
+serde = {version = "1.0.175", features = ["derive"]}
 serde_yaml = "0.9.25"

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -34,7 +34,8 @@ fn load_config() -> Config<'static> {
 pub struct Config<'a> {
     #[serde(borrow)]
     pub container: ContainerSection<'a>,
-    pub tar: Vec<&'a str>
+    #[serde(borrow)]
+    pub include: IncludeSection<'a>
 }
 
 impl<'a> Config<'a> {
@@ -45,6 +46,20 @@ impl<'a> Config<'a> {
     pub fn runtime(&self) -> RuntimeSection {
         self.container.runtime.as_ref().cloned().unwrap_or_default()
     }
+
+    pub fn layers(&self) -> Vec<&'a str> {
+        self.container.layers.as_ref().cloned().unwrap_or_default()
+    }
+
+    pub fn tars(&self) -> Vec<&'a str> {
+        self.include.tar.as_ref().cloned().unwrap_or_default()
+    }
+}
+
+#[derive(Deserialize)]
+pub struct IncludeSection<'a> {
+    #[serde(borrow)]
+    tar: Option<Vec<&'a str>>
 }
 
 #[derive(Deserialize)]
@@ -72,7 +87,7 @@ pub struct ContainerSection<'a> {
     /// Optional additional container layers on top of the
     /// specified base container
     #[serde(default)]
-    pub layers: Vec<&'a str>,
+    layers: Option<Vec<&'a str>>,
 
     /// Optional registration setup
     /// Container runtime parameters
@@ -90,7 +105,7 @@ pub struct RuntimeSection<'a> {
     /// The behavior of sudo can be controlled via the
     /// file /etc/sudoers
     #[serde(borrow)]
-    pub runas: &'a str,
+    pub runas: Option<&'a str>,
 
     /// Resume the container from previous execution.
     ///
@@ -115,5 +130,5 @@ pub struct RuntimeSection<'a> {
     /// For details on podman options please consult the
     /// podman documentation.
     #[serde(default)]
-    pub podman: Vec<&'a str>,
+    pub podman: Option<Vec<&'a str>>,
 }

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -1,0 +1,119 @@
+use lazy_static::lazy_static;
+use serde::Deserialize;
+use std::{env, path::PathBuf, fs};
+
+use crate::defaults;
+
+lazy_static! {
+    static ref CONFIG: Config<'static> = load_config();
+}
+
+/// Returns the config singleton
+/// 
+/// Will initialize the config on first call and return the cached version afterwards
+pub fn config() -> &'static Config<'static> {
+    &CONFIG
+}
+
+fn get_base_path() -> PathBuf {
+    which::which(env::args().next().expect("Arg 0 must be present")).expect("Symlink should exist")
+}
+
+fn load_config() -> Config<'static> {
+    let base_path = get_base_path();
+    let base_path  = base_path.file_name().unwrap().to_str().unwrap();
+    let content = fs::read_to_string(format!("{}/{}.yaml", defaults::CONTAINER_FLAKE_DIR, base_path));
+    
+    // Leak the data to make it static
+    // Safety: This does not cause a reocurring memory leak since `load_config` is only called once
+    let content = Box::leak(content.unwrap().into_boxed_str());
+    serde_yaml::from_str(content).unwrap()
+}
+
+#[derive(Deserialize)]
+pub struct Config<'a> {
+    #[serde(borrow)]
+    pub container: ContainerSection<'a>,
+    pub tar: Vec<&'a str>
+}
+
+impl<'a> Config<'a> {
+    pub fn is_delta_container(&self) -> bool {
+        self.container.base_container.is_some()
+    }
+
+    pub fn runtime(&self) -> RuntimeSection {
+        self.container.runtime.as_ref().cloned().unwrap_or_default()
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ContainerSection<'a> {
+    /// Mandatory registration setup
+    /// Name of the container in the local registry
+    pub name: &'a str,
+
+    /// Path of the program to call inside of the container (target)
+    pub target_app_path: Option<&'a str>,
+
+    /// Path of the program to register on the host
+    pub host_app_path: &'a str,
+
+    /// Optional base container to use with a delta 'container: name'
+    ///
+    /// If specified the given 'container: name' is expected to be
+    /// an overlay for the specified base_container. podman-pilot
+    /// combines the 'container: name' with the base_container into
+    /// one overlay and starts the result as a container instance
+    ///
+    /// Default: not_specified
+    pub base_container: Option<&'a str>,
+
+    /// Optional additional container layers on top of the
+    /// specified base container
+    #[serde(default)]
+    pub layers: Vec<&'a str>,
+
+    /// Optional registration setup
+    /// Container runtime parameters
+    #[serde(default)]
+    pub runtime: Option<RuntimeSection<'a>>,
+}
+
+#[derive(Deserialize, Default, Clone)]
+pub struct RuntimeSection<'a> {
+    /// Run the container engine as a user other than the
+    /// default target user root. The user may be either
+    /// a user name or a numeric user-ID (UID) prefixed
+    /// with the ‘#’ character (e.g. #0 for UID 0). The call
+    /// of the container engine is performed by sudo.
+    /// The behavior of sudo can be controlled via the
+    /// file /etc/sudoers
+    #[serde(borrow)]
+    pub runas: &'a str,
+
+    /// Resume the container from previous execution.
+    ///
+    /// If the container is still running, the app will be
+    /// executed inside of this container instance.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub resume: bool,
+
+    /// Attach to the container if still running, rather than
+    /// executing the app again. Only makes sense for interactive
+    /// sessions like a shell running as app in the container.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub attach: bool,
+
+    /// Caller arguments for the podman engine in the format:
+    /// - PODMAN_OPTION_NAME_AND_OPTIONAL_VALUE
+    ///
+    /// For details on podman options please consult the
+    /// podman documentation.
+    #[serde(default)]
+    pub podman: Vec<&'a str>,
+}

--- a/podman-pilot/src/error.rs
+++ b/podman-pilot/src/error.rs
@@ -1,0 +1,181 @@
+use std::{
+    error::Error,
+    ffi::OsStr,
+    fmt::{Debug, Display, Write},
+    process::{Command, ExitCode, Output, Termination},
+};
+
+#[derive(Debug)]
+pub enum FlakeError {
+    /// The pilot tried to run a sub command and failed
+    CommandError(CommandError),
+    /// There was an error in an IO operation
+    IO(std::io::Error),
+    /// This flake is already running
+    AlreadyRunning,
+}
+
+impl Display for FlakeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FlakeError::CommandError(err) => std::fmt::Display::fmt(err, f),
+            FlakeError::IO(err) => std::fmt::Display::fmt(err, f),
+            FlakeError::AlreadyRunning => {
+                f.write_str("Container id in use by another instance, consider @NAME argument")
+            }
+        }
+    }
+}
+
+impl Termination for FlakeError {
+    /// A failed sub command will forward its error code
+    ///
+    /// All other errors are represented as Failure
+    fn report(self) -> std::process::ExitCode {
+        match self {
+            FlakeError::CommandError(CommandError {
+                base: ProcessError::ExecutionError(Output { status, ..}),
+                ..
+            }) => match status.code() {
+                Some(code) => (code as u8).into(),
+                None => ExitCode::FAILURE,
+            },
+            _ => ExitCode::FAILURE,
+        }
+    }
+}
+
+impl Error for FlakeError {}
+
+impl From<std::io::Error> for FlakeError {
+    fn from(value: std::io::Error) -> Self {
+        Self::IO(value)
+    }
+}
+
+impl From<CommandError> for FlakeError {
+    fn from(value: CommandError) -> Self {
+        Self::CommandError(value)
+    }
+}
+
+#[derive(Debug)]
+pub enum ProcessError {
+    /// The Command failed to execute properly
+    IO(std::io::Error),
+    // The Command terminated correctly but with unwanted results (e.g. wrong return code)
+    ExecutionError(std::process::Output),
+}
+
+impl Error for ProcessError {}
+
+impl Display for ProcessError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProcessError::IO(io) => std::fmt::Display::fmt(&io, f),
+            ProcessError::ExecutionError(output) => {
+                f.write_str("Failed with code ")?;
+                std::fmt::Display::fmt(&output.status, f)
+            }
+        }
+    }
+}
+
+impl From<std::process::Output> for ProcessError {
+    fn from(value: std::process::Output) -> Self {
+        Self::ExecutionError(value)
+    }
+}
+
+impl From<std::io::Error> for ProcessError {
+    fn from(value: std::io::Error) -> Self {
+        Self::IO(value)
+    }
+}
+
+#[derive(Debug)]
+pub struct CommandError {
+    pub base: ProcessError,
+    pub args: Vec<String>,
+}
+
+impl CommandError {
+    pub fn new(base: ProcessError) -> Self {
+        Self {
+            args: Vec::new(),
+            base,
+        }
+    }
+
+    pub fn with(&mut self, arg: String) -> &mut Self {
+        self.args.push(arg);
+        self
+    }
+}
+
+impl Error for CommandError {}
+
+impl Display for CommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for arg in self.args.iter() {
+            f.write_str(arg)?;
+            f.write_char(' ')?;
+        }
+        std::fmt::Display::fmt(&self.base, f)
+    }
+}
+
+impl From<std::process::Output> for CommandError {
+    fn from(value: std::process::Output) -> Self {
+        Self {
+            base: value.into(),
+            args: Default::default(),
+        }
+    }
+}
+
+impl From<ProcessError> for CommandError {
+    fn from(value: ProcessError) -> Self {
+        Self {
+            base: value,
+            args: Default::default(),
+        }
+    }
+}
+
+pub trait CommandExtTrait {
+    /// Execute this command and return:
+    /// 
+    /// 1. An IO Error if the command could not be run
+    /// 2. An Execution Error if the Command was not successfull
+    /// 3. The [Output] of the Command if the command was executed successfully
+    /// 
+    /// Attaches all args to the resulting error
+    fn perform(&mut self) -> Result<std::process::Output, CommandError>;
+}
+
+impl CommandExtTrait for Command {
+    fn perform(&mut self) -> Result<std::process::Output, CommandError> {
+        let out = self.output().map_err(ProcessError::IO);
+
+        let error: ProcessError = match out {
+            Ok(output) => {
+                if output.status.success() {
+                    return Ok(output);
+                } else {
+                    output.into()
+                }
+            }
+            Err(err) => err.into(),
+        };
+
+        Err(CommandError {
+            base: error,
+            args: self
+                .get_args()
+                .flat_map(OsStr::to_str)
+                .map(ToOwned::to_owned)
+                .collect(),
+        })
+    }
+}

--- a/podman-pilot/src/main.rs
+++ b/podman-pilot/src/main.rs
@@ -32,19 +32,18 @@ use env_logger::Env;
 pub mod app_path;
 pub mod podman;
 pub mod defaults;
+pub mod config;
 
 fn main() {
     setup_logger();
 
     let program_path = app_path::program_abs_path();
     let program_name = app_path::basename(&program_path);
-    let runtime_config = app_path::program_config(&program_name);
 
-    let container = podman::create(&program_name, &runtime_config);
+    let container = podman::create(&program_name);
     let cid = &container[0];
     podman::start(
         &program_name,
-        &runtime_config,
         cid
     );
 }

--- a/podman-pilot/src/main.rs
+++ b/podman-pilot/src/main.rs
@@ -26,26 +26,50 @@ extern crate log;
 
 #[cfg(test)]
 pub mod tests;
+pub mod error;
 
+use std::process::{ExitCode, Termination};
+
+use config::config;
 use env_logger::Env;
+use error::FlakeError;
 
 pub mod app_path;
 pub mod podman;
 pub mod defaults;
 pub mod config;
 
-fn main() {
+fn main() -> ExitCode {
     setup_logger();
+    // load config now so we can terminate early if the config is invalid
+    config();
+    // past here there should be no more panics
+
+    let result = run();
+
+    // TODO: implement cleanup function 
+    // cleanup()
+
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            error!("{err}");
+            err.report()
+        },
+    }
+}
+
+fn run() -> Result<(), FlakeError> {
 
     let program_path = app_path::program_abs_path();
     let program_name = app_path::basename(&program_path);
 
-    let container = podman::create(&program_name);
-    let cid = &container[0];
+    let container = podman::create(&program_name)?;
+    let cid = &container.0;
     podman::start(
         &program_name,
         cid
-    );
+    )
 }
 
 fn setup_logger() {

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -404,7 +404,7 @@ pub fn call_instance(
         }
     }
     debug(&format!("{:?}", call.get_args()));
-    call.perform()?;
+    call.status()?;
     Ok(())
 }
 

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -24,11 +24,11 @@
 use spinoff::{Spinner, spinners, Color};
 use std::path::Path;
 use std::process::{Command, Stdio};
-use std::process::exit;
 use std::env;
 use std::fs;
 use crate::config::{RuntimeSection, config};
 use crate::defaults::debug;
+use crate::error::{FlakeError, CommandError, CommandExtTrait};
 use tempfile::tempfile;
 use std::io::{Write, Read};
 use std::fs::File;
@@ -39,7 +39,7 @@ use crate::defaults;
 
 pub fn create(
     program_name: &String
-) -> Vec<String> {
+) -> Result<(String, String), FlakeError> {
     /*!
     Create container for later execution of program_name.
     The container name and all other settings to run the program
@@ -112,7 +112,6 @@ pub fn create(
         - tar-archive-file-name-to-include
     !*/
     let args: Vec<String> = env::args().collect();
-    let mut result: Vec<String> = Vec::new();
     let mut layers: Vec<String> = Vec::new();
 
     // setup container ID file name
@@ -165,38 +164,25 @@ pub fn create(
         .arg("--cidfile").arg(&container_cid_file);
 
     // Make sure CID dir exists
-    init_cid_dir();
+    init_cid_dir()?;
 
     // Check early return condition in resume mode
-    if Path::new(&container_cid_file).exists() && gc_cid_file(&container_cid_file, runas) && (resume || attach) {
+    if Path::new(&container_cid_file).exists() && gc_cid_file(&container_cid_file, runas).is_ok() && (resume || attach) {
         // resume or attach mode is active and container exists
         // report ID value and its ID file name
-        match fs::read_to_string(&container_cid_file) {
-            Ok(cid) => {
-                result.push(cid);
-            },
-            Err(error) => {
-                // cid file exists but could not be read
-                panic!("Error reading CID: {:?}", error);
-            }
-        }
-        result.push(container_cid_file);
-        return result;
+
+        let cid = fs::read_to_string(&container_cid_file)?;
+
+        return Ok((cid, container_cid_file));
     }
 
     // Garbage collect occasionally
-    gc(runas);
+    // TODO: Behaviour (continue on error) retained from previous implementation, is this correct?
+    let _ = gc(runas);
 
     // Sanity check
     if Path::new(&container_cid_file).exists() {
-        // we are about to create a container for which a
-        // cid file already exists. podman create will fail with
-        // an error but will also create the container which is
-        // unwanted. Thus we check this condition here
-        error!(
-            "Container id in use by another instance, consider @NAME argument"
-        );
-        exit(1)
+        return Err(FlakeError::AlreadyRunning);
     }
 
     // create the container with configured runtime arguments
@@ -247,146 +233,119 @@ pub fn create(
             }
         }
     }
-
+    
     // create container
     debug(&format!("{:?}", app.get_args()));
     let spinner = Spinner::new(
         spinners::Line, "Launching flake...", Color::Yellow
     );
-    match app.output() {
-        Ok(output) => {
-            if output.status.success() {
-                let cid = String::from_utf8_lossy(&output.stdout)
-                    .strip_suffix('\n').unwrap().to_string();
-                result.push(cid);
-                result.push(container_cid_file);
-
-                if delta_container || has_includes {
-                    debug("Mounting instance for provisioning workload");
-                    let mut provision_ok = true;
-                    let instance_mount_point = mount_container(
-                        &result[0], runas, false
-                    );
-
-                    if delta_container {
-                        // Create tmpfile to hold accumulated removed data
-                        let removed_files: File;
-                        match tempfile() {
-                            Ok(file) => {
-                                removed_files = file
-                            },
-                            Err(error) => {
-                                spinner.fail("Flake launch has failed");
-                                panic!("Failed to create tempfile: {}", error)
-                            }
-                        }
-                        debug("Provisioning delta container...");
-                        update_removed_files(
-                            &instance_mount_point, &removed_files
-                        );
-                        debug(&format!(
-                            "Adding main app [{}] to layer list", container_name
-                        ));
-                        layers.push(container_name.to_string());
-                        for layer in layers {
-                            debug(&format!(
-                                "Syncing delta dependencies [{}]...", layer
-                            ));
-                            let app_mount_point = mount_container(
-                                &layer, runas, true
-                            );
-                            update_removed_files(
-                                &app_mount_point, &removed_files
-                            );
-                            provision_ok = sync_delta(
-                                &app_mount_point, &instance_mount_point, runas
-                            );
-                            umount_container(&layer, runas, true);
-                            if ! provision_ok {
-                                break
-                            }
-                        }
-                        if provision_ok {
-                            debug("Syncing host dependencies...");
-                            provision_ok = sync_host(
-                                &instance_mount_point, &removed_files, runas
-                            )
-                        }
-                        umount_container(&result[0], runas, false);
-                    }
-
-                    if has_includes && provision_ok {
-                        debug("Syncing includes...");
-                        provision_ok = sync_includes(
-                            &instance_mount_point, runas
-                        )
-                    }
-
-                    if ! provision_ok {
-                        spinner.fail("Flake launch has failed");
-                        panic!("Failed to provision container")
-                    }
-                }
-                spinner.success("Launching flake");
-                return result;
-            }
-            spinner.fail("Flake launch has failed");
-            panic!(
-                "Failed to create container: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
+    
+    match run_podman_creation(app, delta_container, has_includes, runas, container_name, layers, &container_cid_file) {
+        Ok(container) => {
+            spinner.success("Launching flake");
+            Ok(container)            
         },
-        Err(error) => {
+        Err(err) => {
             spinner.fail("Flake launch has failed");
-            panic!("Failed to execute podman: {:?}", error)
+            Err(err)            
+        },
+    }
+
+}
+
+fn run_podman_creation(
+    mut app: Command, 
+    delta_container: bool, 
+    has_includes: bool, 
+    runas: Option<&str>,
+    container_name: &str,
+    mut layers: Vec<String>,
+    container_cid_file: &str
+) -> Result<(String, String), FlakeError> {
+
+    let output = app.perform()?;
+
+    let cid = String::from_utf8_lossy(&output.stdout).trim_end_matches('\n').to_owned();
+
+    if delta_container || has_includes {
+        debug("Mounting instance for provisioning workload");
+        let instance_mount_point = mount_container(
+            &cid, runas, false
+        )?;
+
+        if delta_container {
+            // Create tmpfile to hold accumulated removed data
+            let removed_files = tempfile()?;
+
+            debug("Provisioning delta container...");
+            update_removed_files(
+                &instance_mount_point, &removed_files
+            )?;
+            debug(&format!(
+                "Adding main app [{}] to layer list", container_name
+            ));
+            layers.push(container_name.to_string());
+            for layer in layers {
+                debug(&format!(
+                    "Syncing delta dependencies [{}]...", layer
+                ));
+                let app_mount_point = mount_container(
+                    &layer, runas, true
+                )?;
+                update_removed_files(
+                    &app_mount_point, &removed_files
+                )?;
+                sync_delta(
+                    &app_mount_point, &instance_mount_point, runas
+                )?;
+                // TODO: Behaviour (continue on error) retained from previous implementation, is this correct?
+                let _ = umount_container(&layer, runas, true);
+            }
+            debug("Syncing host dependencies...");
+            sync_host(&instance_mount_point, &removed_files, runas)?;
+            
+            let _ = umount_container(&cid, runas, false);
+        }
+
+        if has_includes {
+            debug("Syncing includes...");
+            sync_includes(&instance_mount_point, runas)?;
         }
     }
+    Ok((cid, container_cid_file.to_owned()))
+        
 }
 
 pub fn start(
     program_name: &str, cid: &str
-) {
+) -> Result<(), FlakeError> {
     /*!
     Start container with the given container ID
-
-    podman-pilot exits with the return code from podman after this function
     !*/
 
     let RuntimeSection { runas, resume, attach, .. } = config().runtime();
     
-    let is_running = container_running(cid, runas);
+    let is_running = container_running(cid, runas)?;
 
-    let status_code = if is_running {
+    if is_running {
 
         if attach {
             // 1. Attach to running container
-            call_instance(
-                "attach", cid, program_name, runas
-            )
+            call_instance("attach", cid, program_name, runas)?;
         } else {
             // 2. Execute app in running container
-            call_instance(
-                "exec", cid, program_name, runas
-            )
+            call_instance("exec", cid, program_name, runas)?;
         }
     } else if resume {
         // 3. Startup resume type container and execute app
-        let status_code = call_instance(
-            "start", cid, program_name, runas
-        );
-        if status_code == 0 {
-            call_instance(
-                "exec", cid, program_name, runas
-            )
-        } else { status_code }
+        call_instance("start", cid, program_name, runas)?;
+        call_instance("exec", cid, program_name, runas)?;
     } else {
         // 4. Startup container
-        call_instance(
-            "start", cid, program_name, runas
-        )
+        call_instance("start", cid, program_name, runas)?;
     };
 
-    exit(status_code)
+    Ok(())
 }
 
 pub fn get_target_app_path(
@@ -406,7 +365,7 @@ pub fn get_target_app_path(
 pub fn call_instance(
     action: &str, cid: &str, program_name: &str,
     user: Option<&str>
-) -> i32 {
+) -> Result<(), FlakeError> {
     /*!
     Call container ID based podman commands
     !*/
@@ -445,22 +404,14 @@ pub fn call_instance(
             }
         }
     }
-    let mut status_code = 255;
     debug(&format!("{:?}", call.get_args()));
-    match call.status() {
-        Ok(status) => {
-            status_code = status.code().unwrap();
-        },
-        Err(error) => {
-            error!("Failed to execute podman {}: {:?}", action, error)
-        }
-    }
-    status_code
+    call.perform()?;
+    Ok(())
 }
 
 pub fn mount_container(
     container_name: &str, user: Option<&str>, as_image: bool
-) -> String {
+) -> Result<String, FlakeError> {
     /*!
     Mount container and return mount point
     !*/
@@ -469,34 +420,23 @@ pub fn mount_container(
         call.arg("--user").arg(user);
     }
     if as_image {
-        if ! container_image_exists(container_name, user) {
-            pull(container_name, user);
+        if ! container_image_exists(container_name, user)? {
+            pull(container_name, user)?;
         }
         call.arg("podman").arg("image").arg("mount").arg(container_name);
     } else {
         call.arg("podman").arg("mount").arg(container_name);
     }
     debug(&format!("{:?}", call.get_args()));
-    match call.output() {
-        Ok(output) => {
-            if output.status.success() {
-                return String::from_utf8_lossy(&output.stdout)
-                    .strip_suffix('\n').unwrap().to_string()
-            }
-            panic!(
-                "Failed to mount container image: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        },
-        Err(error) => {
-            panic!("Failed to execute podman: {:?}", error)
-        }
-    }
+
+    let output = call.perform()?;
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim_end_matches('\n').to_owned())
 }
 
 pub fn umount_container(
     mount_point: &str, user: Option<&str>, as_image: bool
-) -> i32 {
+) -> Result<(), FlakeError> {
     /*!
     Umount container image
     !*/
@@ -511,27 +451,18 @@ pub fn umount_container(
     } else {
         call.arg("podman").arg("umount").arg(mount_point);
     }
-    let mut status_code = 255;
     debug(&format!("{:?}", call.get_args()));
-    match call.status() {
-        Ok(status) => {
-            status_code = status.code().unwrap();
-        },
-        Err(error) => {
-            error!("Failed to execute podman image umount: {:?}", error)
-        }
-    }
-    status_code
+    call.perform()?;
+    Ok(())
 }
 
 pub fn sync_includes(
     target: &String, user: Option<&str>
-) -> bool {
+) -> Result<(), FlakeError> {
     /*!
     Sync custom include data to target path
     !*/
     let tar_includes = &config().tars();
-    let mut status_code = 0;
     
     for tar in tar_includes {
         debug(&format!("Adding tar include: [{}]", tar));
@@ -543,26 +474,16 @@ pub fn sync_includes(
             .arg("-C").arg(target)
             .arg("-xf").arg(tar);
         debug(&format!("{:?}", call.get_args()));
-        match call.output() {
-            Ok(output) => {
-                debug(&String::from_utf8_lossy(&output.stdout));
-                debug(&String::from_utf8_lossy(&output.stderr));
-                status_code = output.status.code().unwrap();
-            },
-            Err(error) => {
-                panic!("Failed to execute tar: {:?}", error)
-            }
-        }
+        let output = call.perform()?;
+        debug(&String::from_utf8_lossy(&output.stdout));
+        debug(&String::from_utf8_lossy(&output.stderr));
     }
-    if status_code == 0 {
-        return true
-    }
-    false
+    Ok(())
 }
 
 pub fn sync_delta(
     source: &String, target: &String, user: Option<&str>
-) -> bool {
+) -> Result<(), CommandError> {
     /*!
     Sync data from source path to target path
     !*/
@@ -574,57 +495,33 @@ pub fn sync_delta(
         .arg("-av")
         .arg(format!("{}/", &source))
         .arg(format!("{}/", &target));
-    let status_code;
     debug(&format!("{:?}", call.get_args()));
-    match call.output() {
-        Ok(output) => {
-            debug(&String::from_utf8_lossy(&output.stdout));
-            status_code = output.status.code().unwrap();
-        },
-        Err(error) => {
-            panic!("Failed to execute rsync: {:?}", error)
-        }
-    }
-    if status_code == 0 {
-        return true
-    }
-    false
+
+    call.perform()?;
+
+    Ok(())
 }
 
 pub fn sync_host(
     target: &String, mut removed_files: &File, user: Option<&str>
-) -> bool {
+) -> Result<(), FlakeError> {
     /*!
     Sync files/dirs specified in target/defaults::HOST_DEPENDENCIES
     from the running host to the target path
     !*/
     let mut removed_files_contents = String::new();
     let host_deps = format!("{}/{}", &target, defaults::HOST_DEPENDENCIES);
-    removed_files.seek(SeekFrom::Start(0)).unwrap();
-    match removed_files.read_to_string(&mut removed_files_contents) {
-        Ok(_) => {
-            if removed_files_contents.is_empty() {
-                debug("There are no host dependencies to resolve");
-                return true
-            }
-            match File::create(&host_deps) {
-                Ok(mut removed) => {
-                    match removed.write_all(removed_files_contents.as_bytes()) {
-                        Ok(_) => { },
-                        Err(error) => {
-                            panic!("Write failed {}: {:?}", host_deps, error);
-                        }
-                    }
-                },
-                Err(error) => {
-                    panic!("Error creating {}: {:?}", host_deps, error);
-                }
-            }
-        },
-        Err(error) => {
-            panic!("Error reading from file descriptor: {:?}", error);
-        }
+    removed_files.seek(SeekFrom::Start(0))?;
+    removed_files.read_to_string(&mut removed_files_contents)?;
+
+
+    if removed_files_contents.is_empty() {
+        debug("There are no host dependencies to resolve");
+        return Ok(())
     }
+
+    File::create(&host_deps)?.write_all(removed_files_contents.as_bytes())?;
+
     let mut call = Command::new("sudo");
     if let Some(user) = user {
         call.arg("--user").arg(user);
@@ -635,41 +532,21 @@ pub fn sync_host(
         .arg("--files-from").arg(&host_deps)
         .arg("/")
         .arg(format!("{}/", &target));
-    let status_code;
     debug(&format!("{:?}", call.get_args()));
-    match call.output() {
-        Ok(output) => {
-            debug(&String::from_utf8_lossy(&output.stdout));
-            status_code = output.status.code().unwrap();
-        },
-        Err(error) => {
-            panic!("Failed to execute rsync: {:?}", error)
-        }
-    }
-    if status_code == 0 {
-        return true
-    }
-    false
+
+    call.perform()?;
+    Ok(())
 }
 
-pub fn init_cid_dir() {
+pub fn init_cid_dir() -> Result<(), FlakeError> {
     if ! Path::new(defaults::CONTAINER_CID_DIR).is_dir() {
-        if ! chmod(defaults::CONTAINER_DIR, "755", Some("root")) {
-            panic!(
-                "Failed to set permissions 755 on {}",
-                defaults::CONTAINER_DIR
-            );
-        }
-        if ! mkdir(defaults::CONTAINER_CID_DIR, "777", Some("root")) {
-            panic!(
-                "Failed to create CID dir: {}",
-                defaults::CONTAINER_CID_DIR
-            );
-        }
+        chmod(defaults::CONTAINER_DIR, "755", Some("root"))?;
+        mkdir(defaults::CONTAINER_CID_DIR, "777", Some("root"))?;
     }
+    Ok(())
 }
 
-pub fn container_running(cid: &str, user: Option<&str>) -> bool {
+pub fn container_running(cid: &str, user: Option<&str>) -> Result<bool, CommandError> {
     /*!
     Check if container with specified cid is running
     !*/
@@ -681,31 +558,26 @@ pub fn container_running(cid: &str, user: Option<&str>) -> bool {
     running.arg("podman")
         .arg("ps").arg("--format").arg("{{.ID}}");
     debug(&format!("{:?}", running.get_args()));
-    match running.output() {
-        Ok(output) => {
-            let mut running_cids = String::new();
-            running_cids.push_str(
-                &String::from_utf8_lossy(&output.stdout)
-            );
-            for running_cid in running_cids.lines() {
-                if cid.starts_with(running_cid) {
-                    running_status = true;
-                    break
-                }
-            }
-        },
-        Err(error) => {
-            panic!("Failed to execute podman ps: {:?}", error)
+
+    let output = running.perform()?;
+    let mut running_cids = String::new();
+    running_cids.push_str(
+        &String::from_utf8_lossy(&output.stdout)
+    );
+    for running_cid in running_cids.lines() {
+        if cid.starts_with(running_cid) {
+            running_status = true;
+            break
         }
     }
-    running_status
+    
+    Ok(running_status)
 }
 
-pub fn container_image_exists(name: &str, user: Option<&str>) -> bool {
+pub fn container_image_exists(name: &str, user: Option<&str>) -> Result<bool, std::io::Error> {
     /*!
     Check if container image is present in local registry
     !*/
-    let mut exists_status = false;
     let mut exists = Command::new("sudo");
     if let Some(user) = user {
         exists.arg("--user").arg(user);
@@ -713,20 +585,10 @@ pub fn container_image_exists(name: &str, user: Option<&str>) -> bool {
     exists.arg("podman")
         .arg("image").arg("exists").arg(name);
     debug(&format!("{:?}", exists.get_args()));
-    match exists.status() {
-        Ok(status) => {
-            if status.code().unwrap() == 0 {
-                exists_status = true
-            }
-        },
-        Err(error) => {
-            panic!("Failed to execute podman image exists: {:?}", error)
-        }
-    }
-    exists_status
+    Ok(exists.status()?.success())
 }
 
-pub fn pull(uri: &str, user: Option<&str>) {
+pub fn pull(uri: &str, user: Option<&str>) -> Result<(), FlakeError> {
     /*!
     Call podman pull and prune with the provided uri
     !*/
@@ -736,34 +598,26 @@ pub fn pull(uri: &str, user: Option<&str>) {
     }
     pull.arg("podman").arg("pull").arg(uri);
     debug(&format!("{:?}", pull.get_args()));
-    match pull.output() {
-        Ok(output) => {
-            if ! output.status.success() {
-                panic!(
-                    "Failed to fetch container: {}",
-                    String::from_utf8_lossy(&output.stderr)
-                );
-            } else {
-                let mut prune = Command::new("sudo");
-                if let Some(user) = user {
-                    prune.arg("--user").arg(user);
-                }
-                prune.arg("podman").arg("image").arg("prune").arg("--force");
-                match prune.status() {
-                    Ok(status) => { debug(&format!("{:?}", status)) },
-                    Err(error) => { debug(&format!("{:?}", error)) }
-                }
-            }
-        }
-        Err(error) => {
-            panic!("Failed to call podman pull: {}", error)
-        }
+
+    pull.perform()?;
+
+    let mut prune = Command::new("sudo");
+    if let Some(user) = user {
+        prune.arg("--user").arg(user);
     }
+
+    prune.arg("podman").arg("image").arg("prune").arg("--force");
+    match prune.status() {
+        Ok(status) => { debug(&format!("{:?}", status)) },
+        Err(error) => { debug(&format!("{:?}", error)) }
+    }
+
+    Ok(())
 }
 
 pub fn update_removed_files(
     target: &String, mut accumulated_file: &File
-) {
+) -> Result<(), std::io::Error> {
     /*!
     Take the contents of the given removed_file and append it
     to the accumulated_file
@@ -771,70 +625,34 @@ pub fn update_removed_files(
     let host_deps = format!("{}/{}", &target, defaults::HOST_DEPENDENCIES);
     debug(&format!("Looking up host deps from {}", host_deps));
     if Path::new(&host_deps).exists() {
-        match fs::read_to_string(&host_deps) {
-            Ok(data) => {
-                debug("Adding host deps...");
-                debug(&String::from_utf8_lossy(data.as_bytes()));
-                match accumulated_file.write_all(data.as_bytes()) {
-                    Ok(_) => { },
-                    Err(error) => {
-                        panic!("Writing to descriptor failed: {:?}", error);
-                    }
-                }
-            },
-            Err(error) => {
-                // host_deps file exists but could not be read
-                panic!("Error reading {}: {:?}", host_deps, error);
-            }
-        }
+        let data = fs::read_to_string(&host_deps)?;
+        debug("Adding host deps...");
+        debug(&String::from_utf8_lossy(data.as_bytes()));
+        accumulated_file.write_all(data.as_bytes())?;
     }
+    Ok(())
 }
 
-pub fn gc_cid_file(container_cid_file: &String, user: Option<&str>) -> bool {
+pub fn gc_cid_file(container_cid_file: &String, user: Option<&str>) -> Result<(), FlakeError> {
     /*!
     Check if container exists according to the specified
     container_cid_file. Garbage cleanup the container_cid_file
     if no longer present. Return a true value if the container
     exists, in any other case return false.
     !*/
-    let mut cid_status = false;
-    match fs::read_to_string(container_cid_file) {
-        Ok(cid) => {
-            let mut exists = Command::new("sudo");
-            if let Some(user) = user {
-                exists.arg("--user").arg(user);
-            }
-            exists.arg("podman")
-                .arg("container").arg("exists").arg(&cid);
-            match exists.status() {
-                Ok(status) => {
-                    if status.code().unwrap() != 0 {
-                        match fs::remove_file(container_cid_file) {
-                            Ok(_) => { },
-                            Err(error) => {
-                                error!("Failed to remove CID: {:?}", error)
-                            }
-                        }
-                    } else {
-                        cid_status = true
-                    }
-                },
-                Err(error) => {
-                    error!(
-                        "Failed to execute podman container exists: {:?}",
-                        error
-                    )
-                }
-            }
-        },
-        Err(error) => {
-            error!("Error reading CID: {:?}", error);
-        }
+    let cid = fs::read_to_string(container_cid_file)?;
+    let mut exists = Command::new("sudo");
+    if let Some(user) = user {
+        exists.arg("--user").arg(user);
     }
-    cid_status
+    exists.arg("podman")
+        .arg("container").arg("exists").arg(&cid);
+
+    exists.perform()?;
+    Ok(())
 }
 
-pub fn chmod(filename: &str, mode: &str, user: Option<&str>) -> bool {
+pub fn chmod(filename: &str, mode: &str, user: Option<&str>) -> Result<(), CommandError> {
     /*!
     Chmod filename via sudo
     !*/
@@ -842,18 +660,11 @@ pub fn chmod(filename: &str, mode: &str, user: Option<&str>) -> bool {
     if let Some(user) = user {
         call.arg("--user").arg(user);
     }
-    call.arg("chmod").arg(mode).arg(filename);
-    match call.status() {
-        Ok(_) => { },
-        Err(error) => {
-            error!("Failed to chmod: {}: {:?}", filename, error);
-            return false
-        }
-    }
-    true
+    call.arg("chmod").arg(mode).arg(filename).perform()?;
+    Ok(())
 }
 
-pub fn mkdir(dirname: &str, mode: &str, user: Option<&str>) -> bool {
+pub fn mkdir(dirname: &str, mode: &str, user: Option<&str>) -> Result<(), CommandError> {
     /*!
     Make directory via sudo
     !*/
@@ -861,32 +672,25 @@ pub fn mkdir(dirname: &str, mode: &str, user: Option<&str>) -> bool {
     if let Some(user) = user {
         call.arg("--user").arg(user);
     }
-    call.arg("mkdir").arg("-p").arg("-m").arg(mode).arg(dirname);
-    match call.status() {
-        Ok(_) => { },
-        Err(error) => {
-            error!("Failed to mkdir: {}: {:?}", dirname, error);
-            return false
-        }
-    }
-    true
+    call.arg("mkdir").arg("-p").arg("-m").arg(mode).arg(dirname).perform()?;
+    Ok(())
 }
 
-pub fn gc(user: Option<&str>) {
+pub fn gc(user: Option<&str>) -> Result<(), std::io::Error> {
     /*!
     Garbage collect CID files for which no container exists anymore
     !*/
     let mut cid_file_names: Vec<String> = Vec::new();
     let mut cid_file_count: i32 = 0;
-    let paths = fs::read_dir(defaults::CONTAINER_CID_DIR).unwrap();
+    let paths = fs::read_dir(defaults::CONTAINER_CID_DIR)?;
     for path in paths {
-        cid_file_names.push(format!("{}", path.unwrap().path().display()));
+        cid_file_names.push(format!("{}", path?.path().display()));
         cid_file_count += 1;
     }
-    if cid_file_count <= defaults::GC_THRESHOLD {
-        return
+    if cid_file_count > defaults::GC_THRESHOLD {
+        for container_cid_file in cid_file_names {
+            let _ = gc_cid_file(&container_cid_file, user);
+        }
     }
-    for container_cid_file in cid_file_names {
-        gc_cid_file(&container_cid_file, user);
-    }
+    Ok(())
 }

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -22,13 +22,12 @@
 // SOFTWARE.
 //
 use spinoff::{Spinner, spinners, Color};
-use yaml_rust::Yaml;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::process::exit;
 use std::env;
 use std::fs;
-use crate::app_path::program_config_file;
+use crate::config::{RuntimeSection, config};
 use crate::defaults::debug;
 use tempfile::tempfile;
 use std::io::{Write, Read};
@@ -39,7 +38,7 @@ use std::io::SeekFrom;
 use crate::defaults;
 
 pub fn create(
-    program_name: &String, runtime_config: &[Yaml]
+    program_name: &String
 ) -> Vec<String> {
     /*!
     Create container for later execution of program_name.
@@ -130,65 +129,33 @@ pub fn create(
     }
     container_cid_file = format!("{}.cid", container_cid_file);
 
-    let container_section = &runtime_config[0]["container"];
+    let container_section = &config().container;
 
     // check for includes
-    let include_section = &runtime_config[0]["include"];
-    let tar_includes = &include_section["tar"];
-    let has_includes = tar_includes.as_vec().is_some();
+    let tar_includes = &config().tar;
+    let has_includes = !tar_includes.is_empty();
 
     // setup podman container to use
-    if container_section["name"].as_str().is_none() {
-        error!("No 'name' attribute specified in {}",
-            program_config_file(program_name)
-        );
-        exit(1)
-    }
-    let container_name = container_section["name"].as_str().unwrap();
+    let container_name = container_section.name;
 
     // setup base container if specified
-    let container_base_name;
-    let delta_container;
-    if container_section["base_container"].as_str().is_some() {
-        // get base container name
-        container_base_name = container_section["base_container"]
-            .as_str().unwrap();
+    let delta_container = container_section.base_container.is_some();
+    let container_base_name= container_section.base_container.unwrap_or_default();
+
+    if container_section.base_container.is_some() {
         // get additional container layers
-        let layer_section = &container_section["layers"];
-        if layer_section.as_vec().is_some() {
-            for layer in layer_section.as_vec().unwrap() {
-                debug(&format!("Adding layer: [{}]", layer.as_str().unwrap()));
-                layers.push(layer.as_str().unwrap().to_string());
-            }
-        }
-        delta_container = true;
-    } else {
-        container_base_name = "";
-        delta_container = false;
+
+        layers.extend(container_section.layers.iter()
+            .inspect(|layer| debug(&format!("Adding layer: [{layer}]")))
+            .map(|x| (*x).to_owned()));
     }
 
     // setup app command path name to call
-    let target_app_path = get_target_app_path(program_name, runtime_config);
+    let target_app_path = get_target_app_path(program_name);
 
     // get runtime section
-    let runtime_section = &container_section["runtime"];
-
-    // setup container operation mode
-    let mut resume: bool = false;
-    let mut attach: bool = false;
-    let mut runas = String::new();
-
-    if runtime_section.as_hash().is_some() {
-        if ! &runtime_section["resume"].as_bool().is_none() {
-            resume = runtime_section["resume"].as_bool().unwrap();
-        }
-        if ! &runtime_section["attach"].as_bool().is_none() {
-            attach = runtime_section["attach"].as_bool().unwrap();
-        }
-        if ! &runtime_section["runas"].as_str().is_none() {
-            runas.push_str(runtime_section["runas"].as_str().unwrap());
-        }
-    }
+    let RuntimeSection { runas, resume, attach, .. } = config().runtime();
+    let runas = runas.to_owned();
 
     let mut app = Command::new("sudo");
     if ! runas.is_empty() {
@@ -234,20 +201,10 @@ pub fn create(
 
     // create the container with configured runtime arguments
     let mut has_runtime_arguments: bool = false;
-    if runtime_section.as_hash().is_some() {
-        let podman_section = &runtime_section["podman"];
-        if let Some(podman_section) = podman_section.as_vec() {
-            has_runtime_arguments = true;
-            for opt in podman_section {
-                let mut split_opt = opt.as_str().unwrap().splitn(2, ' ');
-                let opt_name = split_opt.next();
-                let opt_value = split_opt.next();
-                app.arg(opt_name.unwrap());
-                if let Some(opt_value) = opt_value {
-                    app.arg(opt_value);
-                }
-            }
-        }
+    if let Some(RuntimeSection { podman, .. }) = &config().container.runtime {
+
+        app.args(podman.iter().flat_map(|x| x.splitn(2, ' ')));
+        has_runtime_arguments = !podman.is_empty();
     }
 
     // setup default runtime arguments if not configured
@@ -359,7 +316,7 @@ pub fn create(
                     if has_includes && provision_ok {
                         debug("Syncing includes...");
                         provision_ok = sync_includes(
-                            &instance_mount_point, runtime_config, &runas
+                            &instance_mount_point, &runas
                         )
                     }
 
@@ -385,19 +342,16 @@ pub fn create(
 }
 
 pub fn start(
-    program_name: &str, runtime_config: &[Yaml], cid: &str
+    program_name: &str, cid: &str
 ) {
     /*!
     Start container with the given container ID
 
     podman-pilot exits with the return code from podman after this function
     !*/
-    let container_section = &runtime_config[0]["container"];
-    let runtime_section = &container_section["runtime"];
 
-    let resume = runtime_section.as_hash().and(runtime_section["resume"].as_bool()).unwrap_or_default();
-    let attach = runtime_section.as_hash().and(runtime_section["attach"].as_bool()).unwrap_or_default();
-    let runas = runtime_section.as_hash().and(runtime_section["runas"].as_str()).unwrap_or_default().to_owned();
+    let RuntimeSection { runas, resume, attach, .. } = config().runtime();
+    let runas = runas.to_owned();
     
     let is_running = container_running(cid, &runas);
 
@@ -406,28 +360,28 @@ pub fn start(
         if attach {
             // 1. Attach to running container
             call_instance(
-                "attach", cid, program_name, runtime_config, &runas
+                "attach", cid, program_name, &runas
             )
         } else {
             // 2. Execute app in running container
             call_instance(
-                "exec", cid, program_name, runtime_config, &runas
+                "exec", cid, program_name, &runas
             )
         }
     } else if resume {
         // 3. Startup resume type container and execute app
         let status_code = call_instance(
-            "start", cid, program_name, runtime_config, &runas
+            "start", cid, program_name, &runas
         );
         if status_code == 0 {
             call_instance(
-                "exec", cid, program_name, runtime_config, &runas
+                "exec", cid, program_name, &runas
             )
         } else { status_code }
     } else {
         // 4. Startup container
         call_instance(
-            "start", cid, program_name, runtime_config, &runas
+            "start", cid, program_name, &runas
         )
     };
 
@@ -435,7 +389,7 @@ pub fn start(
 }
 
 pub fn get_target_app_path(
-    program_name: &str, runtime_config: &[Yaml]
+    program_name: &str
 ) -> String {
     /*!
     setup application command path name
@@ -445,23 +399,20 @@ pub fn get_target_app_path(
     configuration file
     !*/
 
-    runtime_config[0]["container"]["target_app_path"].as_str().unwrap_or(program_name).to_owned()
+    config().container.target_app_path.unwrap_or(program_name).to_owned()
 }
 
 pub fn call_instance(
     action: &str, cid: &str, program_name: &str,
-    runtime_config: &[Yaml], user: &str
+    user: &str
 ) -> i32 {
     /*!
     Call container ID based podman commands
     !*/
     let args: Vec<String> = env::args().collect();
-    let container_section = &runtime_config[0]["container"];
-    let runtime_section = &container_section["runtime"];
-    let mut resume: bool = false;
-    if runtime_section.as_hash().is_some() && ! &runtime_section["resume"].as_bool().is_none() {
-        resume = runtime_section["resume"].as_bool().unwrap();
-    }
+
+    let RuntimeSection { resume, .. } = config().runtime();
+
     let mut call = Command::new("sudo");
     if action == "create" || action == "rm" {
         call.stderr(Stdio::null());
@@ -485,7 +436,7 @@ pub fn call_instance(
     call.arg(cid);
     if action == "exec" {
         call.arg(
-            get_target_app_path(program_name, runtime_config)
+            get_target_app_path(program_name)
         );
         for arg in &args[1..] {
             if ! arg.starts_with('@') {
@@ -573,34 +524,32 @@ pub fn umount_container(
 }
 
 pub fn sync_includes(
-    target: &String, runtime_config: &[Yaml], user: &String
+    target: &String, user: &String
 ) -> bool {
     /*!
     Sync custom include data to target path
     !*/
-    let include_section = &runtime_config[0]["include"];
-    let tar_includes = &include_section["tar"];
+    let tar_includes = &config().tar;
     let mut status_code = 0;
-    if tar_includes.as_vec().is_some() {
-        for tar in tar_includes.as_vec().unwrap() {
-            debug(&format!("Adding tar include: [{}]", tar.as_str().unwrap()));
-            let mut call = Command::new("sudo");
-            if ! user.is_empty() {
-                call.arg("--user").arg(user);
-            }
-            call.arg("tar")
-                .arg("-C").arg(target)
-                .arg("-xf").arg(tar.as_str().unwrap());
-            debug(&format!("{:?}", call.get_args()));
-            match call.output() {
-                Ok(output) => {
-                    debug(&String::from_utf8_lossy(&output.stdout));
-                    debug(&String::from_utf8_lossy(&output.stderr));
-                    status_code = output.status.code().unwrap();
-                },
-                Err(error) => {
-                    panic!("Failed to execute tar: {:?}", error)
-                }
+    
+    for tar in tar_includes {
+        debug(&format!("Adding tar include: [{}]", tar));
+        let mut call = Command::new("sudo");
+        if ! user.is_empty() {
+            call.arg("--user").arg(user);
+        }
+        call.arg("tar")
+            .arg("-C").arg(target)
+            .arg("-xf").arg(tar);
+        debug(&format!("{:?}", call.get_args()));
+        match call.output() {
+            Ok(output) => {
+                debug(&String::from_utf8_lossy(&output.stdout));
+                debug(&String::from_utf8_lossy(&output.stderr));
+                status_code = output.status.code().unwrap();
+            },
+            Err(error) => {
+                panic!("Failed to execute tar: {:?}", error)
             }
         }
     }


### PR DESCRIPTION
Builds on top of #131 


Replaces all `unwrap()`, `panic!()` and `exit()` calls in podman.rs with Errors that are propagated to back up to the main function.
1. Makes function API cleaner and more consistent
3. Clearly marks which functions can error
4. `Result` is a 'must_use' type, so errors can no longer be missed on accident
5. Enables cleanup of an error state in the future by not terminating immediately

Since all errors simply propagate back up to `main()` the external behavior should be completely unchanged except for some hard coded error messages (could be added back in if needed).

Sorry for the big diff, but this time it's not possible to make it smaller since almost all return types were changed. Diff could be reduced in size by only adding `Result` to some methods, but this would only needlessly complicate the process in my eyes.
