### PR TITLE
Moved spinners to stderr

### DIFF
--- a/firecracker-pilot/src/firecracker.rs
+++ b/firecracker-pilot/src/firecracker.rs
@@ -207,8 +207,8 @@ pub fn create(
     }
 
     // Setup VM...
-    let spinner = Spinner::new(
-        spinners::Line, "Launching flake...", Color::Yellow
+    let spinner = Spinner::new_with_stream(
+        spinners::Line, "Launching flake...", Color::Yellow, spinoff::Streams::Stderr
     );
 
     // Create initial vm_id_file with process ID set to 0

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -250,8 +250,8 @@ pub fn create(
 
     // create container
     debug(&format!("{:?}", app.get_args()));
-    let spinner = Spinner::new(
-        spinners::Line, "Launching flake...", Color::Yellow
+    let spinner = Spinner::new_with_stream(
+        spinners::Line, "Launching flake...", Color::Yellow, spinoff::Streams::Stderr
     );
     match app.output() {
         Ok(output) => {


### PR DESCRIPTION
Fixes #139 

Moves the spinners to stderr so the flakes produce a clean output on stdout
