### PR TITLE
Reactivate binary stripping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,9 @@
+[profile.release]
+strip = true
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"
+
 [workspace]
 members = ["flake-ctl", "podman-pilot", "firecracker-pilot", "firecracker-pilot/guestvm-tools/sci", "firecracker-pilot/firecracker-service/*"]

--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,6 @@ build: man
 	cargo build -v --release
 	cd firecracker-pilot/guestvm-tools/sci && RUSTFLAGS='-C target-feature=+crt-static' cargo build -v --release --target $(ARCH)-unknown-linux-gnu
 
-compress:
-	upx --best --lzma target/release/podman-pilot
-	upx --best --lzma target/release/flake-ctl
-	upx --best --lzma target/release/firecracker-service
-	upx --best --lzma target/release/firecracker-pilot
-
 clean:
 	cd podman-pilot && cargo -v clean
 	cd firecracker-pilot && cargo -v clean

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ sourcetar:
 		rm -rf {}/src \; -exec mkdir -p {}/src \; -exec touch {}/src/lib.rs \; -exec rm -rf {}/lib \;
 	find package/flake-pilot -type d -wholename "*/vendor/windows*" -prune -exec \
 		rm -rf {}/src \; -exec mkdir -p {}/src \;  -exec touch {}/src/lib.rs \; -exec rm -rf {}/lib \;
-	
+
 	rm -rf package/flake-pilot/vendor/web-sys/src/*
 	rm -rf package/flake-pilot/vendor/web-sys/webidls
 	touch package/flake-pilot/vendor/web-sys/src/lib.rs
@@ -62,10 +62,12 @@ sourcetar:
 .PHONY:build
 build: man
 	cargo build -v --release
+	cd firecracker-pilot/guestvm-tools/sci && RUSTFLAGS='-C target-feature=+crt-static' cargo build -v --release --target $(ARCH)-unknown-linux-gnu
+
+compress:
 	upx --best --lzma target/release/podman-pilot
 	upx --best --lzma target/release/flake-ctl
 	upx --best --lzma target/release/firecracker-service
-	cd firecracker-pilot/guestvm-tools/sci && RUSTFLAGS='-C target-feature=+crt-static' cargo build -v --release --target $(ARCH)-unknown-linux-gnu
 	upx --best --lzma target/release/firecracker-pilot
 
 clean:

--- a/firecracker-pilot/Cargo.toml
+++ b/firecracker-pilot/Cargo.toml
@@ -1,5 +1,5 @@
 [profile.release]
-# strip = true
+strip = true
 opt-level = "z"
 lto = true
 codegen-units = 1

--- a/firecracker-pilot/Cargo.toml
+++ b/firecracker-pilot/Cargo.toml
@@ -1,10 +1,3 @@
-[profile.release]
-strip = true
-opt-level = "z"
-lto = true
-codegen-units = 1
-panic = "abort"
-
 [package]
 name = "firecracker-pilot"
 version = "2.2.19"

--- a/firecracker-pilot/firecracker-service/service-communication/Cargo.toml
+++ b/firecracker-pilot/firecracker-service/service-communication/Cargo.toml
@@ -1,5 +1,5 @@
 [profile.release]
-# strip = true
+strip = true
 opt-level = "z"
 lto = true
 codegen-units = 1

--- a/firecracker-pilot/firecracker-service/service-communication/Cargo.toml
+++ b/firecracker-pilot/firecracker-service/service-communication/Cargo.toml
@@ -1,10 +1,3 @@
-[profile.release]
-strip = true
-opt-level = "z"
-lto = true
-codegen-units = 1
-panic = "abort"
-
 [package]
 name = "firecracker-service-communication"
 version = "2.2.19"

--- a/firecracker-pilot/firecracker-service/service/Cargo.toml
+++ b/firecracker-pilot/firecracker-service/service/Cargo.toml
@@ -1,5 +1,5 @@
 [profile.release]
-# strip = true
+strip = true
 opt-level = "z"
 lto = true
 codegen-units = 1

--- a/firecracker-pilot/firecracker-service/service/Cargo.toml
+++ b/firecracker-pilot/firecracker-service/service/Cargo.toml
@@ -1,10 +1,3 @@
-[profile.release]
-strip = true
-opt-level = "z"
-lto = true
-codegen-units = 1
-panic = "abort"
-
 [package]
 name = "firecracker-service"
 version = "2.2.19"

--- a/flake-ctl/Cargo.toml
+++ b/flake-ctl/Cargo.toml
@@ -1,5 +1,5 @@
 [profile.release]
-# strip = true
+strip = true
 opt-level = "z"
 lto = true
 codegen-units = 1

--- a/flake-ctl/Cargo.toml
+++ b/flake-ctl/Cargo.toml
@@ -1,10 +1,3 @@
-[profile.release]
-strip = true
-opt-level = "z"
-lto = true
-codegen-units = 1
-panic = "abort"
-
 [package]
 name = "flake-ctl"
 version = "2.2.19"

--- a/package/flake-pilot.spec
+++ b/package/flake-pilot.spec
@@ -44,7 +44,6 @@ BuildRequires:  python3-docutils
 %if 0%{?suse_version}
 BuildRequires:  rust
 BuildRequires:  cargo
-BuildRequires:  upx
 BuildRequires:  openssl-devel
 BuildRequires:  glibc-devel-static
 BuildRequires:  kiwi-settings
@@ -52,7 +51,6 @@ BuildRequires:  python3-Pygments
 %endif
 %if 0%{?debian} || 0%{?ubuntu}
 BuildRequires:  rust-all
-BuildRequires:  upx-ucl
 BuildRequires:  libssl-dev
 BuildRequires:  openssl
 BuildRequires:  pkg-config

--- a/podman-pilot/Cargo.toml
+++ b/podman-pilot/Cargo.toml
@@ -1,5 +1,5 @@
 [profile.release]
-# strip = true
+strip = true
 opt-level = "z"
 lto = true
 codegen-units = 1

--- a/podman-pilot/Cargo.toml
+++ b/podman-pilot/Cargo.toml
@@ -1,10 +1,3 @@
-[profile.release]
-strip = true
-opt-level = "z"
-lto = true
-codegen-units = 1
-panic = "abort"
-
 [package]
 name = "podman-pilot"
 version = "2.2.19"


### PR DESCRIPTION
If there is no any particular reasons why we should not remove symbols information, then this should be activated back. However I do see the reason not to UPX-compress the release binaries by default, because it does not do any impact on memory-allocated size, however, it burns CPU to unpack the binary every launch, while disk is cheap. Some systems detect UPX compressed binaries as a virus, which only adds to the problem.

Whoever still needs UPX can use `make compress` as an extra step.