### PR TITLE
Refactor port allocation for UDS socket

### DIFF
--- a/doc/firecracker-pilot.rst
+++ b/doc/firecracker-pilot.rst
@@ -111,11 +111,9 @@ arguments exists, the following defaults will apply:
 
 All caller arguments will be passed to the program call inside
 of the instance except for arguments that starts with the '@'
-sign. Caller arguments of this type are only used in the instance
-ID file name but will not be passed to the program call inside of
-the instance. This allows users to differentiate the same
-program call between different instances when using
-a resume based flake setup.
+or '%' sign. Caller arguments of this type are only used for
+the firecracker-pilot startup itself. See the OPTIONS section
+for the available runtime options.
 
 The execution of the program inside of the instance (the VM)
 is managed by an extra program called `sci` and provided with
@@ -135,6 +133,21 @@ the following example image which is hosted on the
 for your images:
 
 - https://build.opensuse.org/package/show/home:marcus.schaefer:delta_containers/firecracker_base_leap_system
+
+OPTIONS
+-------
+
+@NAME
+
+  This allows users to distribute the exact same program call to different
+  instances when using a non resume based flake setup.
+
+%port:number
+
+  This allows to specify a static port assignment for the communication
+  between guest and host in a resume based flake setup. By default
+  firecracker-pilot calculates a port number itself.
+
 
 DEBUGGING
 ---------

--- a/firecracker-pilot/Cargo.toml
+++ b/firecracker-pilot/Cargo.toml
@@ -23,7 +23,6 @@ env_logger = { version = "0.9" }
 tempfile = { version = "3.4" }
 spinoff = { version = "0.7" }
 ubyte = { version = "0.10", features = ["serde"] }
-rand = { version = "0.8" }
 lazy_static = "1.4.0"
 serde_yaml = "0.9.25"
 strum = { version = "0.25.0", features = ["derive"] }

--- a/firecracker-pilot/src/defaults.rs
+++ b/firecracker-pilot/src/defaults.rs
@@ -41,6 +41,9 @@ pub const FIRECRACKER_FLAKE_DIR: &str =
     "/usr/share/flakes";
 pub const FIRECRACKER_VMID_DIR: &str =
     "/var/lib/firecracker/storage/tmp/flakes";
+pub const FIRECRACKER_VSOCK_PREFIX: &str =
+    "/run/sci_cmd_";
+pub const FIRECRACKER_VSOCK_PORT_START: u32 = 49200;
 pub const GC_THRESHOLD: i32 = 20;
 pub const VM_CID: u32 = 3;
 pub const VM_PORT: u32 =

--- a/firecracker-pilot/src/firecracker.rs
+++ b/firecracker-pilot/src/firecracker.rs
@@ -36,7 +36,7 @@ use std::io::{Write, SeekFrom, Seek};
 use std::fs::File;
 use serde::{Serialize, Deserialize};
 use serde_json::{self};
-use rand::Rng;
+use std::collections::HashMap;
 
 use crate::defaults;
 
@@ -341,9 +341,7 @@ pub fn start(
 
     if is_running {
         // 1. Execute app in running VM
-        status_code = execute_command_at_instance(
-            program_name, runas, get_exec_port()
-        );
+        status_code = execute_command_at_instance(program_name, runas);
     } else {
         match NamedTempFile::new() {
             Ok(firecracker_config) => {
@@ -356,9 +354,7 @@ pub fn start(
                     call_instance(
                         &firecracker_config, vm_id_file, runas, is_blocking
                     );
-                    status_code = execute_command_at_instance(
-                        program_name, runas, get_exec_port()
-                    );
+                    status_code = execute_command_at_instance(program_name, runas);
                 } else {
                     // 3. Startup VM and execute app
                     status_code = call_instance(
@@ -441,15 +437,22 @@ pub fn call_instance(
 
 pub fn get_exec_port() -> u32 {
     /*!
-    Create random execution port
+    Find free port
+
+    Note: This method finds a free port within the firecracker-pilot
+    managed port assignments. If the selected port is occupied by
+    another service in the system it will create a conflict. In this
+    case use the pilot call option %port:number to bind to a port
+    of your choice
     !*/
-    let mut random = rand::thread_rng();
-    // FIXME: A more stable version
-    // should check for already running socket connections
-    // and if the same number is used for an already running one
-    // another rand should be called
-    
-    random.gen_range(49200..60000)
+    let pilot_options = get_pilot_run_options();
+    let port;
+    if pilot_options.contains_key("%port") {
+        port = pilot_options["%port"].parse::<u32>().unwrap_or_default();
+    } else {
+        port = defaults::FIRECRACKER_VSOCK_PORT_START + id();
+    }
+    port
 }
 
 pub fn check_connected(program_name: &String, user: User) -> i32 {
@@ -562,7 +565,7 @@ pub fn send_command_to_instance(
 }
 
 pub fn execute_command_at_instance(
-    program_name: &String, user: User, exec_port: u32
+    program_name: &String, user: User
 ) -> i32 {
     /*!
     Send command to a vsoc connected to a running instance
@@ -570,7 +573,8 @@ pub fn execute_command_at_instance(
     let mut status_code;
     let mut retry_count = 0;
     let vsock_uds_path = format!(
-        "/run/sci_cmd_{}.sock", get_meta_name(program_name)
+        "{}{}.sock",
+        defaults::FIRECRACKER_VSOCK_PREFIX, get_meta_name(program_name)
     );
 
     // wait for UDS socket to appear
@@ -595,7 +599,9 @@ pub fn execute_command_at_instance(
 
     // spawn the listener and wait for sci to run the command
     let mut vm_exec = user.run(defaults::SOCAT);
-    vm_exec.arg("-t")
+    let exec_port = get_exec_port();
+    vm_exec
+        .arg("-t")
         .arg("0")
         .arg("-")
         .arg(
@@ -790,7 +796,7 @@ pub fn get_run_cmdline(
     run.push(target_app_path);
     for arg in &args[1..] {
         debug(&format!("Got Argument: {}", arg));
-        if ! arg.starts_with('@') {
+        if ! arg.starts_with('@') && ! arg.starts_with('%') {
             if quote_for_kernel_cmdline {
                 run.push(arg.replace('-', "\\-").to_string());
             } else {
@@ -799,6 +805,27 @@ pub fn get_run_cmdline(
         }
     }
     run
+}
+
+pub fn get_pilot_run_options() -> HashMap<String, String> {
+    /*!
+    read runtime options which are only meant to be used for the
+    pilot and should not interfere with the standard arguments
+    passed along to the command call. For this purpose we deviate
+    from the standard Unix/Linux commandline format and treat
+    options passed as %name:value to be a pilot option
+    !*/
+    let args: Vec<String> = env::args().collect();
+    let mut pilot_options = HashMap::new();
+    for arg in &args[1..] {
+        if arg.starts_with('%') {
+            let (name, value) = arg.rsplit_once(':').unwrap_or_default();
+            if ! name.is_empty() {
+                pilot_options.insert(name.to_string(), value.to_string());
+            }
+        }
+    }
+    pilot_options
 }
 
 pub fn vm_running(vmid: &String, user: User) -> bool {


### PR DESCRIPTION
When using the firecracker-pilot in a resume type flake, the pilot creates a UDS socket for listening on data. Each of this socket connections requires a free port. The former implementation selects the socket by a random number within a given range. However, this is not a stable solution and the risk to select an already occupied port is high. This commit refactors the port allocation to a simply calculate a new port from FIRECRACKER_VSOCK_PORT_START + the PID of the pilot process.

* This selection for a free port is also not completely stable as there could be other services on the OS that occupies the selected port for which firecracker-pilot has no information.

Further conversations on this topic brought up some ideas how to select a system wide free port by e.g a kernel module but as a first improvement to the former implementation this commit should serve the purpose.

**How to reproduce**

```
flake-ctl firecracker pull --name leap --kis-image https://download.opensuse.org/repositories/home:/marcus.schaefer:/delta_containers/images_15.4/firecracker-basesystem.$(uname -m).tar.xz

flake-ctl firecracker register --vm leap --app $HOME/mybash --target /bin/bash --overlay-size 20GiB --resume

for i in 1 2 3 4 5;do ~/mybash --version;done
```

This Fixes #114