### PR TITLE
Extract common code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,9 @@
 [workspace]
-members = ["flake-ctl", "podman-pilot", "firecracker-pilot", "firecracker-pilot/guestvm-tools/sci", "firecracker-pilot/firecracker-service/*"]
+members = [
+    "flake-ctl", 
+    "podman-pilot", 
+    "firecracker-pilot", 
+    "firecracker-pilot/guestvm-tools/sci", 
+    "firecracker-pilot/firecracker-service/*", 
+    "common"
+]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "flakes"
+version = "0.1.0"
+edition = "2021"
+crate-type = "lib"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0.185", features = ["derive"] }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod user;

--- a/common/src/user.rs
+++ b/common/src/user.rs
@@ -16,7 +16,7 @@ impl<'a> From<&'a str> for User<'a> {
 
 impl<'a> User<'a> {
     pub const ROOT: User<'static> = User { name: Some("root")};
-    
+
     pub fn run<S: AsRef<OsStr>>(&self, command: S) -> Command {
         let mut c = Command::new("sudo");
         if let Some(name) = self.name {

--- a/common/src/user.rs
+++ b/common/src/user.rs
@@ -1,0 +1,28 @@
+use std::{process::Command, ffi::OsStr};
+
+use serde::{Serialize, Deserialize};
+
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+pub struct User<'a> {
+    name: Option<&'a str>
+}
+
+impl<'a> From<&'a str> for User<'a> {
+    fn from(value: &'a str) -> Self {
+        Self { name: Some(value) }
+    }
+}
+
+impl<'a> User<'a> {
+    pub const ROOT: User<'static> = User { name: Some("root")};
+    
+    pub fn run<S: AsRef<OsStr>>(&self, command: S) -> Command {
+        let mut c = Command::new("sudo");
+        if let Some(name) = self.name {
+            c.arg("--user").arg(name);
+        }
+        c.arg(command);
+        c
+    }
+}

--- a/firecracker-pilot/Cargo.toml
+++ b/firecracker-pilot/Cargo.toml
@@ -27,3 +27,4 @@ rand = { version = "0.8" }
 lazy_static = "1.4.0"
 serde_yaml = "0.9.25"
 strum = { version = "0.25.0", features = ["derive"] }
+flakes = { version = "0.1.0 ", path= "../common" }

--- a/firecracker-pilot/src/config.rs
+++ b/firecracker-pilot/src/config.rs
@@ -130,7 +130,7 @@ pub struct RuntimeSection<'a> {
     /// of the VM engine is performed by sudo.
     /// The behavior of sudo can be controlled via the
     /// file /etc/sudoers
-    #[serde(borrow)]
+    #[serde(borrow, flatten)]
     pub runas: User<'a>,
 
     /// Resume the VM from previous execution.

--- a/firecracker-pilot/src/config.rs
+++ b/firecracker-pilot/src/config.rs
@@ -1,3 +1,4 @@
+use flakes::user::User;
 use lazy_static::lazy_static;
 use serde::Deserialize;
 use strum::Display;
@@ -130,7 +131,7 @@ pub struct RuntimeSection<'a> {
     /// The behavior of sudo can be controlled via the
     /// file /etc/sudoers
     #[serde(borrow)]
-    pub runas: Option<&'a str>,
+    pub runas: User<'a>,
 
     /// Resume the VM from previous execution.
     /// If the VM is still running, the app will be

--- a/podman-pilot/Cargo.toml
+++ b/podman-pilot/Cargo.toml
@@ -24,3 +24,4 @@ lazy_static = "1.4.0"
 serde = {version = "1.0.175", features = ["derive"]}
 serde_yaml = "0.9.25"
 thiserror = "1.0.44"
+flakes = { version = "0.1.0 ", path= "../common" }

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -1,3 +1,4 @@
+use flakes::user::User;
 use lazy_static::lazy_static;
 use serde::Deserialize;
 use std::{env, path::PathBuf, fs};
@@ -149,7 +150,7 @@ pub struct RuntimeSection<'a> {
     /// The behavior of sudo can be controlled via the
     /// file /etc/sudoers
     #[serde(borrow)]
-    pub runas: Option<&'a str>,
+    pub runas: User<'a>,
 
     /// Resume the container from previous execution.
     ///

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -149,7 +149,7 @@ pub struct RuntimeSection<'a> {
     /// of the container engine is performed by sudo.
     /// The behavior of sudo can be controlled via the
     /// file /etc/sudoers
-    #[serde(borrow)]
+    #[serde(borrow, flatten)]
     pub runas: User<'a>,
 
     /// Resume the container from previous execution.

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -1,3 +1,4 @@
+use flakes::user::User;
 //
 // Copyright (c) 2022 Elektrobit Automotive GmbH
 //
@@ -156,11 +157,8 @@ pub fn create(
     let RuntimeSection { runas, resume, attach, .. } = config().runtime();
     let runas = runas.to_owned();
 
-    let mut app = Command::new("sudo");
-    if let Some(user) = runas {
-        app.arg("--user").arg(&user);
-    }
-    app.arg("podman").arg("create")
+    let mut app = runas.run("podman");
+    app.arg("create")
         .arg("--cidfile").arg(&container_cid_file);
 
     // Make sure CID dir exists
@@ -256,7 +254,7 @@ fn run_podman_creation(
     mut app: Command, 
     delta_container: bool, 
     has_includes: bool, 
-    runas: Option<&str>,
+    runas: User,
     container_name: &str,
     mut layers: Vec<String>,
     container_cid_file: &str
@@ -363,7 +361,7 @@ pub fn get_target_app_path(
 
 pub fn call_instance(
     action: &str, cid: &str, program_name: &str,
-    user: Option<&str>
+    user: User
 ) -> Result<(), FlakeError> {
     /*!
     Call container ID based podman commands
@@ -372,15 +370,12 @@ pub fn call_instance(
 
     let RuntimeSection { resume, .. } = config().runtime();
 
-    let mut call = Command::new("sudo");
+    let mut call = user.run("podman");
     if action == "create" || action == "rm" {
         call.stderr(Stdio::null());
         call.stdout(Stdio::null());
     }
-    if let Some(user) = user {
-        call.arg("--user").arg(user);
-    }
-    call.arg("podman").arg(action);
+    call.arg(action);
     if action == "exec" {
         call.arg("--interactive");
         call.arg("--tty");
@@ -409,22 +404,19 @@ pub fn call_instance(
 }
 
 pub fn mount_container(
-    container_name: &str, user: Option<&str>, as_image: bool
+    container_name: &str, user: User, as_image: bool
 ) -> Result<String, FlakeError> {
     /*!
     Mount container and return mount point
     !*/
-    let mut call = Command::new("sudo");
-    if let Some(user) = user {
-        call.arg("--user").arg(user);
-    }
+    let mut call = user.run("podman");
     if as_image {
         if ! container_image_exists(container_name, user)? {
             pull(container_name, user)?;
         }
-        call.arg("podman").arg("image").arg("mount").arg(container_name);
+        call.arg("image").arg("mount").arg(container_name);
     } else {
-        call.arg("podman").arg("mount").arg(container_name);
+        call.arg("mount").arg(container_name);
     }
     debug(&format!("{:?}", call.get_args()));
 
@@ -434,21 +426,18 @@ pub fn mount_container(
 }
 
 pub fn umount_container(
-    mount_point: &str, user: Option<&str>, as_image: bool
+    mount_point: &str, user: User, as_image: bool
 ) -> Result<(), FlakeError> {
     /*!
     Umount container image
     !*/
-    let mut call = Command::new("sudo");
+    let mut call = user.run("podman");
     call.stderr(Stdio::null());
     call.stdout(Stdio::null());
-    if let Some(user) = user {
-        call.arg("--user").arg(user);
-    }
     if as_image {
-        call.arg("podman").arg("image").arg("umount").arg(mount_point);
+        call.arg("image").arg("umount").arg(mount_point);
     } else {
-        call.arg("podman").arg("umount").arg(mount_point);
+        call.arg("umount").arg(mount_point);
     }
     debug(&format!("{:?}", call.get_args()));
     call.perform()?;
@@ -456,7 +445,7 @@ pub fn umount_container(
 }
 
 pub fn sync_includes(
-    target: &String, user: Option<&str>
+    target: &String, user: User
 ) -> Result<(), FlakeError> {
     /*!
     Sync custom include data to target path
@@ -465,12 +454,8 @@ pub fn sync_includes(
     
     for tar in tar_includes {
         debug(&format!("Adding tar include: [{}]", tar));
-        let mut call = Command::new("sudo");
-        if let Some(user) = user {
-            call.arg("--user").arg(user);
-        }
-        call.arg("tar")
-            .arg("-C").arg(target)
+        let mut call = user.run("tar");
+        call.arg("-C").arg(target)
             .arg("-xf").arg(tar);
         debug(&format!("{:?}", call.get_args()));
         let output = call.perform()?;
@@ -481,17 +466,13 @@ pub fn sync_includes(
 }
 
 pub fn sync_delta(
-    source: &String, target: &String, user: Option<&str>
+    source: &String, target: &String, user: User
 ) -> Result<(), CommandError> {
     /*!
     Sync data from source path to target path
     !*/
-    let mut call = Command::new("sudo");
-    if let Some(user) = user {
-        call.arg("--user").arg(user);
-    }
-    call.arg("rsync")
-        .arg("-av")
+    let mut call = user.run("rsync");
+    call.arg("-av")
         .arg(format!("{}/", &source))
         .arg(format!("{}/", &target));
     debug(&format!("{:?}", call.get_args()));
@@ -502,7 +483,7 @@ pub fn sync_delta(
 }
 
 pub fn sync_host(
-    target: &String, mut removed_files: &File, user: Option<&str>
+    target: &String, mut removed_files: &File, user: User
 ) -> Result<(), FlakeError> {
     /*!
     Sync files/dirs specified in target/defaults::HOST_DEPENDENCIES
@@ -521,12 +502,8 @@ pub fn sync_host(
 
     File::create(&host_deps)?.write_all(removed_files_contents.as_bytes())?;
 
-    let mut call = Command::new("sudo");
-    if let Some(user) = user {
-        call.arg("--user").arg(user);
-    }
-    call.arg("rsync")
-        .arg("-av")
+    let mut call = user.run("rsync");
+    call.arg("-av")
         .arg("--ignore-missing-args")
         .arg("--files-from").arg(&host_deps)
         .arg("/")
@@ -539,23 +516,19 @@ pub fn sync_host(
 
 pub fn init_cid_dir() -> Result<(), FlakeError> {
     if ! Path::new(defaults::CONTAINER_CID_DIR).is_dir() {
-        chmod(defaults::CONTAINER_DIR, "755", Some("root"))?;
-        mkdir(defaults::CONTAINER_CID_DIR, "777", Some("root"))?;
+        chmod(defaults::CONTAINER_DIR, "755", User::ROOT)?;
+        mkdir(defaults::CONTAINER_CID_DIR, "777", User::ROOT)?;
     }
     Ok(())
 }
 
-pub fn container_running(cid: &str, user: Option<&str>) -> Result<bool, CommandError> {
+pub fn container_running(cid: &str, user: User) -> Result<bool, CommandError> {
     /*!
     Check if container with specified cid is running
     !*/
     let mut running_status = false;
-    let mut running = Command::new("sudo");
-    if let Some(user) = user {
-        running.arg("--user").arg(user);
-    }
-    running.arg("podman")
-        .arg("ps").arg("--format").arg("{{.ID}}");
+    let mut running = user.run("podman");
+    running.arg("ps").arg("--format").arg("{{.ID}}");
     debug(&format!("{:?}", running.get_args()));
 
     let output = running.perform()?;
@@ -573,39 +546,28 @@ pub fn container_running(cid: &str, user: Option<&str>) -> Result<bool, CommandE
     Ok(running_status)
 }
 
-pub fn container_image_exists(name: &str, user: Option<&str>) -> Result<bool, std::io::Error> {
+pub fn container_image_exists(name: &str, user: User) -> Result<bool, std::io::Error> {
     /*!
     Check if container image is present in local registry
     !*/
-    let mut exists = Command::new("sudo");
-    if let Some(user) = user {
-        exists.arg("--user").arg(user);
-    }
-    exists.arg("podman")
-        .arg("image").arg("exists").arg(name);
+    let mut exists = user.run("podman");
+    exists.arg("image").arg("exists").arg(name);
     debug(&format!("{:?}", exists.get_args()));
     Ok(exists.status()?.success())
 }
 
-pub fn pull(uri: &str, user: Option<&str>) -> Result<(), FlakeError> {
+pub fn pull(uri: &str, user: User) -> Result<(), FlakeError> {
     /*!
     Call podman pull and prune with the provided uri
     !*/
-    let mut pull = Command::new("sudo");
-    if let Some(user) = user {
-        pull.arg("--user").arg(user);
-    }
-    pull.arg("podman").arg("pull").arg(uri);
+    let mut pull = user.run("podman");
+    pull.arg("pull").arg(uri);
     debug(&format!("{:?}", pull.get_args()));
 
     pull.perform()?;
 
-    let mut prune = Command::new("sudo");
-    if let Some(user) = user {
-        prune.arg("--user").arg(user);
-    }
-
-    prune.arg("podman").arg("image").arg("prune").arg("--force");
+    let mut prune = user.run("podman");
+    prune.arg("image").arg("prune").arg("--force");
     match prune.status() {
         Ok(status) => { debug(&format!("{:?}", status)) },
         Err(error) => { debug(&format!("{:?}", error)) }
@@ -632,7 +594,7 @@ pub fn update_removed_files(
     Ok(())
 }
 
-pub fn gc_cid_file(container_cid_file: &String, user: Option<&str>) -> Result<bool, FlakeError> {
+pub fn gc_cid_file(container_cid_file: &String, user: User) -> Result<bool, FlakeError> {
     /*!
     Check if container exists according to the specified
     container_cid_file. Garbage cleanup the container_cid_file
@@ -640,12 +602,8 @@ pub fn gc_cid_file(container_cid_file: &String, user: Option<&str>) -> Result<bo
     exists, in any other case return false.
     !*/
     let cid = fs::read_to_string(container_cid_file)?;
-    let mut exists = Command::new("sudo");
-    if let Some(user) = user {
-        exists.arg("--user").arg(user);
-    }
-    exists.arg("podman")
-        .arg("container").arg("exists").arg(&cid);
+    let mut exists = user.run("podman");
+        exists.arg("container").arg("exists").arg(&cid);
 
 
     if !exists.status()?.success() {
@@ -656,31 +614,23 @@ pub fn gc_cid_file(container_cid_file: &String, user: Option<&str>) -> Result<bo
     }
 }
 
-pub fn chmod(filename: &str, mode: &str, user: Option<&str>) -> Result<(), CommandError> {
+pub fn chmod(filename: &str, mode: &str, user: User) -> Result<(), CommandError> {
     /*!
     Chmod filename via sudo
     !*/
-    let mut call = Command::new("sudo");
-    if let Some(user) = user {
-        call.arg("--user").arg(user);
-    }
-    call.arg("chmod").arg(mode).arg(filename).perform()?;
+    user.run("chmod").arg(mode).arg(filename).perform()?;
     Ok(())
 }
 
-pub fn mkdir(dirname: &str, mode: &str, user: Option<&str>) -> Result<(), CommandError> {
+pub fn mkdir(dirname: &str, mode: &str, user: User) -> Result<(), CommandError> {
     /*!
     Make directory via sudo
     !*/
-    let mut call = Command::new("sudo");
-    if let Some(user) = user {
-        call.arg("--user").arg(user);
-    }
-    call.arg("mkdir").arg("-p").arg("-m").arg(mode).arg(dirname).perform()?;
+    user.run("mkdir").arg("-p").arg("-m").arg(mode).arg(dirname).perform()?;
     Ok(())
 }
 
-pub fn gc(user: Option<&str>) -> Result<(), std::io::Error> {
+pub fn gc(user: User) -> Result<(), std::io::Error> {
     /*!
     Garbage collect CID files for which no container exists anymore
     !*/


### PR DESCRIPTION
Create a `User` struct and move the 
```rust
let mut command = Command::new("sudo");
if let Some(user) = user {
        command.arg("--user").arg(user);
}
command.arg(<program>);
```
pattern there.

Now you can write
```rust
let mut command = user.run(<program>);
```

This is only a small first step, we should think about moving other structs and functions (like chmod) into the common lib. Especially the config structs so flake-ctl and the pilots can share them.