### PR TITLE
Add config loader and path resolver

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 
 [dependencies]
 bitflags = { version = "2.4.0", features = ["serde"] }
+lazy_static = "1.4.0"
 nix = { version = "0.27.1", features = ["user"] }
+path-clean = "1.0.1"
 serde = { version = "1.0.185", features = ["derive"] }
 serde_yaml = "0.9.25"
+which = "4.4.2"

--- a/common/src/config/cfg_v1.rs
+++ b/common/src/config/cfg_v1.rs
@@ -251,9 +251,6 @@ impl FlakeCfgV1 {
                 paths: FlakeCfgPaths {
                     exported_app_path: PathBuf::from(spec.get_container().get_target_app_path()),
                     registered_app_path: PathBuf::from(spec.get_container().get_host_app_path()),
-                    vm_rootfs_path: None,
-                    vm_kernel_path: None,
-                    vm_initrd_path: None,
                 },
             },
             engine: FlakeCfgEngine {
@@ -286,11 +283,6 @@ impl FlakeCfgV1 {
                 paths: FlakeCfgPaths {
                     exported_app_path: PathBuf::from(spec.get_vm().get_target_app_path()),
                     registered_app_path: PathBuf::from(spec.get_vm().get_host_app_path()),
-
-                    // XXX: vm-only though
-                    vm_rootfs_path: None,
-                    vm_kernel_path: None,
-                    vm_initrd_path: None,
                 },
             },
             engine: FlakeCfgEngine {

--- a/common/src/config/cfg_v2.rs
+++ b/common/src/config/cfg_v2.rs
@@ -4,6 +4,7 @@ use std::io::Error;
 
 /// Configuration parser, v2.
 pub struct FlakeCfgV2 {
+    #[allow(dead_code)]
     content: Value,
 }
 

--- a/common/src/config/itf.rs
+++ b/common/src/config/itf.rs
@@ -145,38 +145,9 @@ pub struct FlakeCfgPaths {
     // Path on the host where flake is installed as executable symlink
     // to launch exported app
     pub(crate) registered_app_path: PathBuf,
-
-    // Path to rootfs image done by app registration
-    pub(crate) vm_rootfs_path: Option<PathBuf>,
-
-    // Path to kernel image done by app registration
-    pub(crate) vm_kernel_path: Option<PathBuf>,
-
-    // Optional path to initrd image done by app registration
-    pub(crate) vm_initrd_path: Option<PathBuf>,
 }
 
 impl FlakeCfgPaths {
-    /// Returns the initrd path for [`FlakeCfgPaths`].
-    /// The initrd path meant to be of a mounted image.
-    /// See [`FlakeCfgPaths::vm_rootfs_path`]
-    pub fn vm_initrd_path(&self) -> Option<&PathBuf> {
-        self.vm_initrd_path.as_ref()
-    }
-
-    /// Returns the kernel path for [`FlakeCfgPaths`].
-    /// The kernel path meant to be on a mounted image.
-    /// See [`FlakeCfgPaths::vm_rootfs_path`]
-    pub fn vm_kernel_path(&self) -> Option<&PathBuf> {
-        self.vm_kernel_path.as_ref()
-    }
-
-    /// Returns the rootfs path for [`FlakeCfgPaths`].
-    /// The rootfs is expected to be mounted.
-    pub fn vm_rootfs_path(&self) -> Option<&PathBuf> {
-        self.vm_rootfs_path.as_ref()
-    }
-
     /// Returns a reference to the exported app path of [`FlakeCfgPaths`].
     /// **Exported App Path** is a path of an application inside of a flake
     /// which should be launched. It also can be wrapped in
@@ -197,13 +168,7 @@ impl FlakeCfgPaths {
 
 impl Default for FlakeCfgPaths {
     fn default() -> Self {
-        Self {
-            exported_app_path: PathBuf::new(),
-            registered_app_path: PathBuf::new(),
-            vm_initrd_path: None,
-            vm_kernel_path: None,
-            vm_rootfs_path: None,
-        }
+        Self { exported_app_path: PathBuf::new(), registered_app_path: PathBuf::new() }
     }
 }
 

--- a/common/src/config/mod.rs
+++ b/common/src/config/mod.rs
@@ -22,10 +22,10 @@ lazy_static! {
 /// Find path on itself
 fn path_for_app() -> Result<PathBuf, Error> {
     let loc = env::args().next().unwrap();
-    if loc.starts_with("/") {
+    if loc.starts_with('/') {
         // Absolute
         return Ok(PathBuf::from(loc));
-    } else if loc.contains("/") {
+    } else if loc.contains('/') {
         // Relative
         let rel = PathBuf::from(loc);
         if let Ok(loc) = env::current_dir() {
@@ -33,7 +33,7 @@ fn path_for_app() -> Result<PathBuf, Error> {
         }
     } else {
         // Needs resolve
-        if let Ok(loc) = which::which(PathBuf::from(loc).file_name().unwrap().to_str().unwrap().to_string()) {
+        if let Ok(loc) = which::which(PathBuf::from(loc).file_name().unwrap().to_str().unwrap()) {
             return Ok(loc);
         }
     }

--- a/common/src/config/mod.rs
+++ b/common/src/config/mod.rs
@@ -1,5 +1,69 @@
+use self::{cfgparse::FlakeCfgParser, itf::FlakeConfig};
+use lazy_static::lazy_static;
+use std::{env, io::Error, path::PathBuf};
+
 pub mod cfg_v1;
 pub mod cfg_v2;
 pub mod cfgparse;
 pub mod itf;
 pub mod pilots;
+
+lazy_static! {
+    /// Flake directory for all the app configurations and other shared data
+    pub static ref FLAKE_DIR: PathBuf = PathBuf::from("/usr/share/flakes");
+
+    /// Default OCI container directory for storage etc
+    pub static ref DEFAULT_CONTAINER_DIR: PathBuf = PathBuf::from("/var/lib/containers");
+
+    /// CID directory where all OCI containers should store their runtime ID
+    pub static ref CID_DIR: PathBuf = PathBuf::from("/usr/share/flakes/cid");
+}
+
+/// Find path on itself
+fn path_for_app() -> Result<PathBuf, Error> {
+    let loc = env::args().next().unwrap();
+    if loc.starts_with("/") {
+        // Absolute
+        return Ok(PathBuf::from(loc));
+    } else if loc.contains("/") {
+        // Relative
+        let rel = PathBuf::from(loc);
+        if let Ok(loc) = env::current_dir() {
+            return Ok(path_clean::clean(loc.join(rel)));
+        }
+    } else {
+        // Needs resolve
+        if let Ok(loc) = which::which(PathBuf::from(loc).file_name().unwrap().to_str().unwrap().to_string()) {
+            return Ok(loc);
+        }
+    }
+
+    env::current_exe()
+}
+
+/// Load config for the host app path
+pub fn load() -> Result<FlakeConfig, Error> {
+    //pub fn load_for_app() {
+    let app_p = path_for_app().unwrap();
+    let app_ps = app_p.file_name().unwrap().to_str().unwrap().to_string();
+
+    // Get app configuration
+    let cfg_d_paths: Vec<PathBuf> = std::fs::read_dir(FLAKE_DIR.join(app_ps.to_owned() + ".d"))
+        .unwrap()
+        .filter_map(|entry| -> Option<PathBuf> {
+            if let Ok(entry) = entry {
+                if entry.path().is_file() {
+                    if let Some(file_name) = entry.file_name().to_str() {
+                        return Some(PathBuf::from(file_name.to_string()));
+                    }
+                }
+            }
+            None
+        })
+        .collect();
+
+    match FlakeCfgParser::new(FLAKE_DIR.join(app_ps + ".yaml"), cfg_d_paths)?.parse() {
+        Some(cfg) => Ok(cfg),
+        None => Err(Error::new(std::io::ErrorKind::NotFound, "Unable to read configuration")),
+    }
+}


### PR DESCRIPTION
Now configuration can be loaded from one place, paths are taken automatically and all the data from `.d` directories is merged:

```rust
let myconf = flakes::config::load()?;
```