### PR TITLE
v2: path aliases for different behaviours

### DIFF
--- a/common/src/config/cfg_v1.rs
+++ b/common/src/config/cfg_v1.rs
@@ -240,10 +240,10 @@ impl FlakeCfgV1 {
             rt_flags |= InstanceMode::Resume;
         }
 
-        let mut paths: HashMap<PathBuf, Option<FlakeCfgPathProperties>> = HashMap::new();
+        let mut paths: HashMap<PathBuf, FlakeCfgPathProperties> = HashMap::new();
         paths.insert(
             PathBuf::from(spec.get_container().get_target_app_path()),
-            Some(FlakeCfgPathProperties::new(PathBuf::from(spec.get_container().get_host_app_path()))),
+            FlakeCfgPathProperties::new(PathBuf::from(spec.get_container().get_host_app_path())),
         );
 
         FlakeConfig {
@@ -275,10 +275,10 @@ impl FlakeCfgV1 {
             rt_flags |= InstanceMode::Resume;
         }
 
-        let mut paths: HashMap<PathBuf, Option<FlakeCfgPathProperties>> = HashMap::new();
+        let mut paths: HashMap<PathBuf, FlakeCfgPathProperties> = HashMap::new();
         paths.insert(
             PathBuf::from(spec.get_vm().get_target_app_path()),
-            Some(FlakeCfgPathProperties::new(PathBuf::from(spec.get_vm().get_host_app_path()))),
+            FlakeCfgPathProperties::new(PathBuf::from(spec.get_vm().get_host_app_path())),
         );
 
         FlakeConfig {

--- a/common/src/config/cfg_v2.rs
+++ b/common/src/config/cfg_v2.rs
@@ -1,10 +1,39 @@
 use crate::config::{cfgparse::FlakeCfgVersionParser, itf::FlakeConfig};
+use serde::Deserialize;
 use serde_yaml::Value;
-use std::io::Error;
+use std::{collections::HashMap, io::Error};
+
+#[derive(Deserialize, Debug)]
+struct CfgV2Spec {
+    pub(crate) version: u8,
+    pub(crate) runtime: CfgV2Runtime,
+    pub(crate) engine: CfgV2Engine,
+
+    #[serde(rename = "static")]
+    pub(crate) static_data: Option<Vec<String>>,
+}
+
+/// Runtime section
+#[derive(Deserialize, Debug)]
+struct CfgV2Runtime {
+    pub(crate) name: String,
+    pub(crate) path_map: HashMap<String, Value>,
+    pub(crate) base_layer: Option<String>,
+    pub(crate) layers: Option<Vec<String>>,
+    pub(crate) user: Option<String>,
+    pub(crate) instance: Option<String>,
+}
+
+///Engine section
+#[derive(Deserialize, Debug)]
+struct CfgV2Engine {
+    pub(crate) pilot: String,
+    pub(crate) args: Option<Vec<String>>,
+    pub(crate) params: Option<Value>,
+}
 
 /// Configuration parser, v2.
 pub struct FlakeCfgV2 {
-    #[allow(dead_code)]
     content: Value,
 }
 
@@ -12,10 +41,17 @@ impl FlakeCfgV2 {
     pub fn new(content: Value) -> Self {
         FlakeCfgV2 { content }
     }
+
+    fn as_cfg(&self, spec: CfgV2Spec) -> FlakeConfig {
+        FlakeConfig { version: 2, ..Default::default() }
+    }
 }
 
 impl FlakeCfgVersionParser for FlakeCfgV2 {
     fn parse(&self) -> Result<FlakeConfig, Error> {
-        Ok(FlakeConfig::new(Some(2)))
+        match serde_yaml::from_value::<CfgV2Spec>(self.content.to_owned()) {
+            Ok(spec) => Ok(self.as_cfg(spec)),
+            Err(err) => return Err(Error::new(std::io::ErrorKind::InvalidData, format!("Config v2 parse error: {}", err))),
+        }
     }
 }

--- a/common/src/config/cfg_v2.rs
+++ b/common/src/config/cfg_v2.rs
@@ -74,6 +74,8 @@ impl CfgV2Runtime {
                             _ => {}
                         }
                     }
+                } else {
+                    i_mode = self.get_instance();
                 }
                 pmap.insert(
                     PathBuf::from(target.clone()),

--- a/common/src/config/itf.rs
+++ b/common/src/config/itf.rs
@@ -136,6 +136,13 @@ impl Default for FlakeCfgRuntime {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct FlakeCfgPathProperties {
+    pub(crate) exports: PathBuf,
+    pub(crate) run_as: Option<User>,
+    pub(crate) instance_mode: InstanceMode,
+}
+
 /// Paths for various command proxypass between the guest and host
 #[derive(Debug, Clone)]
 pub struct FlakeCfgPaths {

--- a/common/src/config/itf.rs
+++ b/common/src/config/itf.rs
@@ -1,7 +1,7 @@
 use bitflags::bitflags;
 use nix::unistd::User;
 use serde_yaml::Value;
-use std::{default::Default, path::PathBuf};
+use std::{collections::HashMap, default::Default, path::PathBuf};
 
 /// FlakeConfig is an interface for all configuration possible
 /// across all suppirted versions of the config.
@@ -83,7 +83,7 @@ pub struct FlakeCfgRuntime {
 
     pub(crate) instance_mode: InstanceMode,
 
-    pub(crate) paths: FlakeCfgPaths,
+    pub(crate) paths: HashMap<PathBuf, Option<FlakeCfgPathProperties>>,
 }
 
 impl FlakeCfgRuntime {
@@ -117,8 +117,8 @@ impl FlakeCfgRuntime {
         &self.instance_mode
     }
 
-    /// Get `paths` namespace, represented by [`FlakeCfgPaths`] struct.
-    pub fn paths(&self) -> &FlakeCfgPaths {
+    /// Get the path-map
+    pub fn paths(&self) -> &HashMap<PathBuf, Option<FlakeCfgPathProperties>> {
         &self.paths
     }
 }
@@ -131,7 +131,7 @@ impl Default for FlakeCfgRuntime {
             layers: None,
             run_as: None,
             instance_mode: InstanceMode::default(),
-            paths: FlakeCfgPaths::default(),
+            paths: HashMap::default(),
         }
     }
 }
@@ -140,42 +140,27 @@ impl Default for FlakeCfgRuntime {
 pub struct FlakeCfgPathProperties {
     pub(crate) exports: PathBuf,
     pub(crate) run_as: Option<User>,
-    pub(crate) instance_mode: InstanceMode,
+    pub(crate) instance_mode: Option<InstanceMode>,
 }
 
-/// Paths for various command proxypass between the guest and host
-#[derive(Debug, Clone)]
-pub struct FlakeCfgPaths {
-    // Path to the target on the container/VM, that needs to be exported
-    pub(crate) exported_app_path: PathBuf,
-
-    // Path on the host where flake is installed as executable symlink
-    // to launch exported app
-    pub(crate) registered_app_path: PathBuf,
-}
-
-impl FlakeCfgPaths {
-    /// Returns a reference to the exported app path of [`FlakeCfgPaths`].
-    /// **Exported App Path** is a path of an application inside of a flake
-    /// which should be launched. It also can be wrapped in
-    /// any way: scripts or binary launchers.
-    pub fn exported_app_path(&self) -> &PathBuf {
-        &self.exported_app_path
+impl FlakeCfgPathProperties {
+    pub fn new(exports: PathBuf) -> Self {
+        FlakeCfgPathProperties { run_as: None, instance_mode: None, exports }
     }
 
-    /// Returns a reference to the registered app path of [`FlakeCfgPaths`].
-    /// **Registered App Path** is a path of a symlink on the host machine
-    /// where Flake is installed. Calling this path will eventually call
-    /// `exported_app_path` function.
-    /// See [`FlakeCfgPaths::exported_app_path`].
-    pub fn registered_app_path(&self) -> &PathBuf {
-        &self.registered_app_path
+    /// Returns a reference to the exports of this [`FlakeCfgPathProperties`].
+    pub fn exports(&self) -> &PathBuf {
+        &self.exports
     }
-}
 
-impl Default for FlakeCfgPaths {
-    fn default() -> Self {
-        Self { exported_app_path: PathBuf::new(), registered_app_path: PathBuf::new() }
+    /// Returns the user to run-as of this [`FlakeCfgPathProperties`].
+    pub fn run_as(&self) -> Option<&User> {
+        self.run_as.as_ref()
+    }
+
+    /// Returns the instance mode of this [`FlakeCfgPathProperties`].
+    pub fn instance_mode(&self) -> Option<InstanceMode> {
+        self.instance_mode
     }
 }
 

--- a/common/src/config/itf.rs
+++ b/common/src/config/itf.rs
@@ -83,7 +83,7 @@ pub struct FlakeCfgRuntime {
 
     pub(crate) instance_mode: InstanceMode,
 
-    pub(crate) paths: HashMap<PathBuf, Option<FlakeCfgPathProperties>>,
+    pub(crate) paths: HashMap<PathBuf, FlakeCfgPathProperties>,
 }
 
 impl FlakeCfgRuntime {
@@ -118,7 +118,7 @@ impl FlakeCfgRuntime {
     }
 
     /// Get the path-map
-    pub fn paths(&self) -> &HashMap<PathBuf, Option<FlakeCfgPathProperties>> {
+    pub fn paths(&self) -> &HashMap<PathBuf, FlakeCfgPathProperties> {
         &self.paths
     }
 }

--- a/common/src/config/pilots/fc.rs
+++ b/common/src/config/pilots/fc.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use serde::Deserialize;
 use serde_yaml::Value;
 
@@ -35,16 +37,16 @@ impl FirecrackerRuntimeParams {
         self.overlay_size.as_ref()
     }
 
-    pub fn rootfs_image_path(&self) -> &str {
-        self.rootfs_image_path.as_ref()
+    pub fn rootfs_image_path(&self) -> PathBuf {
+        PathBuf::from(self.rootfs_image_path.to_owned())
     }
 
-    pub fn kernel_image_path(&self) -> &str {
-        self.kernel_image_path.as_ref()
+    pub fn kernel_image_path(&self) -> PathBuf {
+        PathBuf::from(self.kernel_image_path.to_owned())
     }
 
-    pub fn initrd_path(&self) -> &str {
-        self.initrd_path.as_ref()
+    pub fn initrd_path(&self) -> PathBuf {
+        PathBuf::from(self.initrd_path.to_owned())
     }
 }
 

--- a/common/tests/cfg_ut.rs
+++ b/common/tests/cfg_ut.rs
@@ -353,7 +353,7 @@ mod cfg_v1_ut_vm {
         ut_rt::tb("cfg-v1/firecracker.yaml".to_string(), |cfg| {
             let params: FirecrackerRuntimeParams = cfg.unwrap().engine().params().unwrap().into();
             assert!(
-                params.rootfs_image_path() == "/var/lib/firecracker/images/NAME/rootfs",
+                params.rootfs_image_path() == PathBuf::from("/var/lib/firecracker/images/NAME/rootfs"),
                 "firecracker/rootfs_image_path should be a valid path"
             );
         });
@@ -364,7 +364,7 @@ mod cfg_v1_ut_vm {
         ut_rt::tb("cfg-v1/firecracker.yaml".to_string(), |cfg| {
             let params: FirecrackerRuntimeParams = cfg.unwrap().engine().params().unwrap().into();
             assert!(
-                params.kernel_image_path() == "/var/lib/firecracker/images/NAME/kernel",
+                params.kernel_image_path() == PathBuf::from("/var/lib/firecracker/images/NAME/kernel"),
                 "firecracker/kernel_image_path should be valid path"
             );
         });
@@ -375,7 +375,7 @@ mod cfg_v1_ut_vm {
         ut_rt::tb("cfg-v1/firecracker.yaml".to_string(), |cfg| {
             let params: FirecrackerRuntimeParams = cfg.unwrap().engine().params().unwrap().into();
             assert!(
-                params.initrd_path() == "/var/lib/firecracker/images/NAME/initrd",
+                params.initrd_path() == PathBuf::from("/var/lib/firecracker/images/NAME/initrd"),
                 "firecracker/initrd_path should be a valid path"
             );
         });

--- a/common/tests/cfg_ut.rs
+++ b/common/tests/cfg_ut.rs
@@ -47,7 +47,7 @@ mod cfg_v1_ut_oci {
     fn test_cfg_v1_pdm_exported_app_path() {
         ut_rt::tb("cfg-v1/podman.yaml".to_string(), |cfg| {
             let cfg = cfg.unwrap();
-            assert!(cfg.runtime().paths().exported_app_path() == &PathBuf::from("/banana/in/the/container"));
+            assert!(cfg.runtime().paths().into_iter().next().unwrap().0 == &PathBuf::from("/banana/in/the/container"));
         });
     }
 
@@ -56,7 +56,10 @@ mod cfg_v1_ut_oci {
     fn test_cfg_v1_pdm_registered_app_path() {
         ut_rt::tb("cfg-v1/podman.yaml".to_string(), |cfg| {
             let cfg = cfg.unwrap();
-            assert!(cfg.runtime().paths().registered_app_path() == &PathBuf::from("/usr/bin/banana"));
+            assert!(
+                cfg.runtime().paths().into_iter().next().unwrap().1.clone().unwrap().exports()
+                    == &PathBuf::from("/usr/bin/banana")
+            );
         });
     }
 
@@ -168,7 +171,7 @@ mod cfg_v1_ut_vm {
     fn test_cfg_v1_vm_target_app_path() {
         ut_rt::tb("cfg-v1/firecracker.yaml".to_string(), |cfg| {
             let cfg = cfg.unwrap();
-            assert!(cfg.runtime().paths().exported_app_path() == &PathBuf::from("/highway/to/hell"));
+            assert!(cfg.runtime().paths().into_iter().next().unwrap().0 == &PathBuf::from("/highway/to/hell"));
         });
     }
 
@@ -177,7 +180,9 @@ mod cfg_v1_ut_vm {
     fn test_cfg_v1_vm_host_app_path() {
         ut_rt::tb("cfg-v1/firecracker.yaml".to_string(), |cfg| {
             let cfg = cfg.unwrap();
-            assert!(cfg.runtime().paths().registered_app_path() == &PathBuf::from("/usr/sbin/hell"));
+            assert!(
+                cfg.runtime().paths().iter().next().unwrap().1.clone().unwrap().exports() == &PathBuf::from("/usr/sbin/hell")
+            );
         });
     }
 

--- a/common/tests/cfg_ut.rs
+++ b/common/tests/cfg_ut.rs
@@ -56,10 +56,7 @@ mod cfg_v1_ut_oci {
     fn test_cfg_v1_pdm_registered_app_path() {
         ut_rt::tb("cfg-v1/podman.yaml".to_string(), |cfg| {
             let cfg = cfg.unwrap();
-            assert!(
-                cfg.runtime().paths().into_iter().next().unwrap().1.clone().unwrap().exports()
-                    == &PathBuf::from("/usr/bin/banana")
-            );
+            assert!(cfg.runtime().paths().into_iter().next().unwrap().1.clone().exports() == &PathBuf::from("/usr/bin/banana"));
         });
     }
 
@@ -180,9 +177,7 @@ mod cfg_v1_ut_vm {
     fn test_cfg_v1_vm_host_app_path() {
         ut_rt::tb("cfg-v1/firecracker.yaml".to_string(), |cfg| {
             let cfg = cfg.unwrap();
-            assert!(
-                cfg.runtime().paths().iter().next().unwrap().1.clone().unwrap().exports() == &PathBuf::from("/usr/sbin/hell")
-            );
+            assert!(cfg.runtime().paths().iter().next().unwrap().1.clone().exports() == &PathBuf::from("/usr/sbin/hell"));
         });
     }
 

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -226,4 +226,15 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_params_rtp_root_fs() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                FirecrackerRuntimeParams::from(cfg.unwrap().engine().params().unwrap()).rootfs_image_path()
+                    == PathBuf::from("/var/lib/firecracker/images/NAME/rootfs"),
+                "Runtime params should have root FS path"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -3,6 +3,8 @@ mod ut_rt;
 /// Unit tests for v2 config
 #[cfg(test)]
 mod cfg_v2_ut {
+    use std::path::PathBuf;
+
     use super::ut_rt;
 
     /// Test v2 overall parse
@@ -28,6 +30,17 @@ mod cfg_v2_ut {
         ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
             assert!(!cfg.clone().unwrap().runtime().paths().is_empty(), "Path map should not be empty");
             assert!(cfg.unwrap().runtime().paths().len() == 4, "Path map should have four elements");
+        });
+    }
+
+    /// Test v2 path map has properties
+    #[test]
+    fn test_cfg_v2_path_map_has_props() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                cfg.unwrap().runtime().paths().get(&PathBuf::from("/usr/bin/banana")).is_some(),
+                "Banana should have some properties!"
+            );
         });
     }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -13,4 +13,12 @@ mod cfg_v2_ut {
             assert!(cfg.unwrap().version() == 2, "Version should be 2");
         });
     }
+
+    /// Test v2 overall parse
+    #[test]
+    fn test_cfg_v2_runtime_name() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(cfg.unwrap().runtime().image_name() == "darth vader", "The name should be defined");
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -55,4 +55,19 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    /// Test v2 path map has specific properties: user
+    #[test]
+    fn test_cfg_v2_path_map_has_spec_props_user() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                cfg.clone().unwrap().runtime().paths().get(&PathBuf::from("/usr/bin/banana")).unwrap().run_as().is_some(),
+                "Banana should have some consumer"
+            );
+            assert!(
+                cfg.unwrap().runtime().paths().get(&PathBuf::from("/usr/bin/banana")).unwrap().run_as().unwrap().uid.is_root(),
+                "Only r00t can eat bananas"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -266,4 +266,11 @@ mod cfg_v2_ut {
             assert!(cfg.unwrap().static_data().get_bundles().is_some(), "There should be some static data");
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_static_data_len() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(cfg.unwrap().static_data().get_bundles().unwrap().len() == 4, "There should be some static data of 4");
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -44,9 +44,9 @@ mod cfg_v2_ut {
         });
     }
 
-    /// Test v2 path map has specific properties
+    /// Test v2 path map has specific properties: exports
     #[test]
-    fn test_cfg_v2_path_map_has_spec_props() {
+    fn test_cfg_v2_path_map_has_spec_props_exports() {
         ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
             assert!(
                 cfg.unwrap().runtime().paths().get(&PathBuf::from("/usr/bin/banana")).unwrap().exports()

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -125,4 +125,11 @@ mod cfg_v2_ut {
             assert!(cfg.unwrap().engine().args().is_some(), "Pilot should have instructions!");
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_args_len() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(cfg.unwrap().engine().args().unwrap().len() == 2, "Pilot should have whole two instructions!");
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -113,9 +113,16 @@ mod cfg_v2_ut {
     }
 
     #[test]
-    fn test_cfg_v2_engine_parsed() {
+    fn test_cfg_v2_engine_pilot() {
         ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
             assert!(cfg.unwrap().engine().pilot() == "RD2D".to_string(), "Pilot should always have RD2D!");
+        });
+    }
+
+    #[test]
+    fn test_cfg_v2_engine_args() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(cfg.unwrap().engine().args().is_some(), "Pilot should have instructions!");
         });
     }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -186,4 +186,14 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_params_rtp_memsize_check() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                FirecrackerRuntimeParams::from(cfg.unwrap().engine().params().unwrap()).mem_size_mib().unwrap() == 0x1000,
+                "Runtime params should have memsize of 4096"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -248,4 +248,15 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_params_rtp_initrd() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                FirecrackerRuntimeParams::from(cfg.unwrap().engine().params().unwrap()).initrd_path()
+                    == PathBuf::from("/var/lib/firecracker/images/NAME/initrd"),
+                "Runtime params should have root initrd path"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -160,8 +160,10 @@ mod cfg_v2_ut {
     #[test]
     fn test_cfg_v2_engine_params_rtp_boot_args() {
         ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
-            let rtp = FirecrackerRuntimeParams::from(cfg.unwrap().engine().params().unwrap());
-            assert!(rtp.boot_args().is_some(), "Runtime params should have boot args!");
+            assert!(
+                FirecrackerRuntimeParams::from(cfg.unwrap().engine().params().unwrap()).boot_args().is_some(),
+                "Runtime params should have boot args!"
+            );
         });
     }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -166,4 +166,14 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_params_rtp_boot_args_len() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                FirecrackerRuntimeParams::from(cfg.unwrap().engine().params().unwrap()).boot_args().unwrap().len() == 7,
+                "Runtime params should have seven params!"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -176,4 +176,14 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_params_rtp_memsize() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                FirecrackerRuntimeParams::from(cfg.unwrap().engine().params().unwrap()).mem_size_mib().is_some(),
+                "Runtime params should have memsize"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -149,4 +149,11 @@ mod cfg_v2_ut {
             assert!(cfg.unwrap().engine().params().is_some(), "Pilot should have parameters!");
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_params_vm_boot_args() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(cfg.unwrap().engine().params().unwrap().get("boot_args").is_some(), "VM should have boot args!");
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -43,4 +43,16 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    /// Test v2 path map has specific properties
+    #[test]
+    fn test_cfg_v2_path_map_has_spec_props() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                cfg.unwrap().runtime().paths().get(&PathBuf::from("/usr/bin/banana")).unwrap().exports()
+                    == &PathBuf::from("/usr/bin/brown-banana"),
+                "Banana should be a bit older than that"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -5,7 +5,7 @@ mod ut_rt;
 mod cfg_v2_ut {
     use std::path::PathBuf;
 
-    use flakes::config::itf::InstanceMode;
+    use flakes::config::{itf::InstanceMode, pilots::fc::FirecrackerRuntimeParams};
 
     use super::ut_rt;
 
@@ -154,6 +154,14 @@ mod cfg_v2_ut {
     fn test_cfg_v2_engine_params_vm_boot_args() {
         ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
             assert!(cfg.unwrap().engine().params().unwrap().get("boot_args").is_some(), "VM should have boot args!");
+        });
+    }
+
+    #[test]
+    fn test_cfg_v2_engine_params_rtp_boot_args() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            let rtp = FirecrackerRuntimeParams::from(cfg.unwrap().engine().params().unwrap());
+            assert!(rtp.boot_args().is_some(), "Runtime params should have boot args!");
         });
     }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -86,4 +86,12 @@ mod cfg_v2_ut {
     }
 
     #[test]
+    fn test_cfg_v2_path_map_has_default_path() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            let p = PathBuf::from("/usr/bin/bash");
+            let banana = cfg.unwrap().clone();
+            let banana = banana.runtime().paths().get(&p).unwrap();
+            assert!(banana.exports() == &p, "Rotten banana should resume");
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -206,4 +206,14 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_params_rtp_cache_type() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                FirecrackerRuntimeParams::from(cfg.unwrap().engine().params().unwrap()).cache_type().unwrap() == "Writeback",
+                "Runtime params should have cache type as writeback"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -94,4 +94,21 @@ mod cfg_v2_ut {
             assert!(banana.exports() == &p, "Rotten banana should resume");
         });
     }
+
+    #[test]
+    fn test_cfg_v2_path_map_default_path_has_common_behaviour() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            let p = PathBuf::from("/usr/bin/bash");
+            let banana = cfg.unwrap().clone();
+            let banana = banana.runtime().paths().get(&p).unwrap();
+            assert!(
+                banana.instance_mode().unwrap() & InstanceMode::Resume == InstanceMode::Resume,
+                "Rotten banana should be resumed"
+            );
+            assert!(
+                banana.instance_mode().unwrap() & InstanceMode::Attach == InstanceMode::Attach,
+                "Rotten banana should be still attached to a tree"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -259,4 +259,11 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_static_data() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(cfg.unwrap().static_data().get_bundles().is_some(), "There should be some static data");
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -142,4 +142,11 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_params_exists() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(cfg.unwrap().engine().params().is_some(), "Pilot should have parameters!");
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -273,4 +273,14 @@ mod cfg_v2_ut {
             assert!(cfg.unwrap().static_data().get_bundles().unwrap().len() == 4, "There should be some static data of 4");
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_static_data_second_value() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                cfg.unwrap().static_data().get_bundles().unwrap().get(1).unwrap() == "extra-files.tar.xz",
+                "Second value should be an .xz archive"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -132,4 +132,14 @@ mod cfg_v2_ut {
             assert!(cfg.unwrap().engine().args().unwrap().len() == 2, "Pilot should have whole two instructions!");
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_args_second_check() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                cfg.unwrap().engine().args().unwrap().get(1).unwrap() == "--foo=bar",
+                "Pilot should know exactly where it goes!"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -216,4 +216,14 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_params_rtp_overlay_size() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                FirecrackerRuntimeParams::from(cfg.unwrap().engine().params().unwrap()).overlay_size().unwrap() == "20GiB",
+                "Runtime params should have overlay size of 20 gigabytes"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -237,4 +237,15 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_params_rtp_kernel_image() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                FirecrackerRuntimeParams::from(cfg.unwrap().engine().params().unwrap()).kernel_image_path()
+                    == PathBuf::from("/var/lib/firecracker/images/NAME/kernel"),
+                "Runtime params should have root kernel path"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -111,4 +111,11 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_parsed() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(cfg.unwrap().engine().pilot() == "RD2D".to_string(), "Pilot should always have RD2D!");
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -196,4 +196,14 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    #[test]
+    fn test_cfg_v2_engine_params_rtp_vcpu() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(
+                FirecrackerRuntimeParams::from(cfg.unwrap().engine().params().unwrap()).vcpu_count().unwrap() == 2,
+                "Runtime params should have some virtual CPUs"
+            );
+        });
+    }
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -5,6 +5,8 @@ mod ut_rt;
 mod cfg_v2_ut {
     use std::path::PathBuf;
 
+    use flakes::config::itf::InstanceMode;
+
     use super::ut_rt;
 
     /// Test v2 overall parse
@@ -70,4 +72,18 @@ mod cfg_v2_ut {
             );
         });
     }
+
+    #[test]
+    fn test_cfg_v2_path_map_has_spec_props_instance_mode() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            let banana = cfg.unwrap().clone();
+            let banana = banana.runtime().paths().get(&PathBuf::from("/usr/bin/rotten-banana")).unwrap();
+            assert!(
+                banana.instance_mode().unwrap() & InstanceMode::Resume == InstanceMode::Resume,
+                "Rotten banana should resume"
+            );
+        });
+    }
+
+    #[test]
 }

--- a/common/tests/cfg_ut_v2.rs
+++ b/common/tests/cfg_ut_v2.rs
@@ -21,4 +21,13 @@ mod cfg_v2_ut {
             assert!(cfg.unwrap().runtime().image_name() == "darth vader", "The name should be defined");
         });
     }
+
+    /// Test v2 path map
+    #[test]
+    fn test_cfg_v2_path_map_present() {
+        ut_rt::tb("cfg-v2/all.yaml".to_string(), |cfg| {
+            assert!(!cfg.clone().unwrap().runtime().paths().is_empty(), "Path map should not be empty");
+            assert!(cfg.unwrap().runtime().paths().len() == 4, "Path map should have four elements");
+        });
+    }
 }

--- a/common/tests/data/cfg-v2/all.yaml
+++ b/common/tests/data/cfg-v2/all.yaml
@@ -62,7 +62,7 @@ runtime:
 
 # Engine settings (per pilot)
 engine:
-  pilot: firecracker
+  pilot: RD2D
   args:
     - -x
     - --foo=bar

--- a/common/tests/data/cfg-v2/all.yaml
+++ b/common/tests/data/cfg-v2/all.yaml
@@ -22,7 +22,7 @@ runtime:
       # Exported path from flake. Default is the same as host path.
       #
       # Optional
-      exports: /usr/bin/foo
+      exports: /usr/bin/brown-banana
 
       # Override general "user" option, specified below
       #

--- a/common/tests/data/cfg-v2/all.yaml
+++ b/common/tests/data/cfg-v2/all.yaml
@@ -4,7 +4,7 @@ version: 2
 
 # All settings for all engines during their runtime
 runtime:
-  name: "name in local registry"
+  name: "darth vader"
 
   # Map of the exported path.
   # Config v1 allows only one app per a flake. It does not


### PR DESCRIPTION
This PR updates path map section interface for v2 config with aliases, where each alias allows different exported flake behaviour.