### PR TITLE
Skip current CID while GC

### DIFF
--- a/pilots/src/oci-pilot/fgc.rs
+++ b/pilots/src/oci-pilot/fgc.rs
@@ -53,16 +53,25 @@ impl CidGarbageCollector {
 
     /// Check all existing CID files for their validity
     pub fn on_all(&self, current: PathBuf) -> Result<(), Error> {
-        log::debug!("GC start");
+        if self.debug {
+            log::debug!("GC start");
+        }
+
         for e in flakes::config::get_cid_store()?.read_dir()?.flatten() {
             if e.path() == current {
                 continue; // skip current CID, which will be examined anyways
             }
-            log::debug!("GC: verifying {:?}", e.file_name());
+
+            if self.debug {
+                log::debug!("GC: verifying {:?}", e.file_name());
+            }
+
             match self.on_cidfile(e.path()) {
                 Ok(r) => {
                     if !r.0 {
-                        log::debug!("GC: Removed {:?}", e.file_name());
+                        if self.debug {
+                            log::debug!("GC: Removed {:?}", e.file_name());
+                        }
                     }
                 }
                 Err(err) => {
@@ -70,7 +79,11 @@ impl CidGarbageCollector {
                 }
             }
         }
-        log::debug!("GC finished");
+
+        if self.debug {
+            log::debug!("GC finished");
+        }
+
         Ok(())
     }
 }

--- a/pilots/src/oci-pilot/fgc.rs
+++ b/pilots/src/oci-pilot/fgc.rs
@@ -68,10 +68,8 @@ impl CidGarbageCollector {
 
             match self.on_cidfile(e.path()) {
                 Ok(r) => {
-                    if !r.0 {
-                        if self.debug {
-                            log::debug!("GC: Removed {:?}", e.file_name());
-                        }
+                    if !r.0 && self.debug {
+                        log::debug!("GC: Removed {:?}", e.file_name());
                     }
                 }
                 Err(err) => {

--- a/pilots/src/oci-pilot/fgc.rs
+++ b/pilots/src/oci-pilot/fgc.rs
@@ -52,9 +52,12 @@ impl CidGarbageCollector {
     }
 
     /// Check all existing CID files for their validity
-    pub fn on_all(&self) -> Result<(), Error> {
+    pub fn on_all(&self, current: PathBuf) -> Result<(), Error> {
         log::debug!("GC start");
         for e in flakes::config::get_cid_store()?.read_dir()?.flatten() {
+            if e.path() == current {
+                continue; // skip current CID, which will be examined anyways
+            }
             match self.on_cidfile(e.path()) {
                 Ok(r) => {
                     if !r.0 {

--- a/pilots/src/oci-pilot/fgc.rs
+++ b/pilots/src/oci-pilot/fgc.rs
@@ -58,14 +58,15 @@ impl CidGarbageCollector {
             if e.path() == current {
                 continue; // skip current CID, which will be examined anyways
             }
+            log::debug!("GC: verifying {:?}", e.file_name());
             match self.on_cidfile(e.path()) {
                 Ok(r) => {
                     if !r.0 {
-                        log::debug!("Removed {:?}", e.file_name());
+                        log::debug!("GC: Removed {:?}", e.file_name());
                     }
                 }
                 Err(err) => {
-                    log::error!("Garbage collector error: {}", err);
+                    log::error!("GC error: {}", err);
                 }
             }
         }

--- a/pilots/src/oci-pilot/prunner.rs
+++ b/pilots/src/oci-pilot/prunner.rs
@@ -70,9 +70,10 @@ impl PodmanRunner {
     }
 
     /// Purge bogus CID files
-    pub(crate) fn cid_collect(&self) -> JoinHandle<Result<(), Error>> {
+    pub(crate) fn cid_collect(&mut self) -> JoinHandle<Result<(), Error>> {
+        let cidf = self.get_cidfile().unwrap().to_owned();
         let gc = self.gc.to_owned();
-        thread::spawn(move || gc.on_all())
+        thread::spawn(move || gc.on_all(cidf))
     }
 
     /// Get CID (should be initialised)


### PR DESCRIPTION
Garbage collector works on background, but should not double-check the current CID.