### PR TITLE
Oci-tty-fix

### DIFF
--- a/pilots/src/oci-pilot/podman.rs
+++ b/pilots/src/oci-pilot/podman.rs
@@ -1,6 +1,6 @@
 use crate::prunner::PodmanRunner;
 use flakes::config::itf::InstanceMode;
-use std::{io::{Error, stdout, Write}, path::PathBuf};
+use std::{io::Error, path::PathBuf};
 
 /// Podman runtime
 ///

--- a/pilots/src/oci-pilot/prunner.rs
+++ b/pilots/src/oci-pilot/prunner.rs
@@ -1,4 +1,4 @@
-use crate::{fgc::CidGarbageCollector, pdsys::PdSysCall};
+use crate::fgc::CidGarbageCollector;
 use flakes::config::itf::{FlakeConfig, InstanceMode};
 use std::path::PathBuf;
 use std::process::Command;
@@ -61,8 +61,8 @@ impl PodmanRunner {
 
         let mut suff = String::from("");
         for arg in std::env::args().collect::<Vec<String>>() {
-            if arg.starts_with('@') {
-                suff = format!("-{}", &arg.to_owned()[1..]);
+            if let Some(arg) = arg.strip_prefix('@') {
+                suff = format!("-{}", &arg);
                 break;
             }
         }
@@ -73,7 +73,7 @@ impl PodmanRunner {
 
     /// Purge bogus CID files
     pub(crate) fn cid_collect(&mut self) -> JoinHandle<Result<(), Error>> {
-        let cidf = self.get_cidfile().unwrap().to_owned();
+        let cidf = self.get_cidfile().unwrap();
         let gc = self.gc.to_owned();
         thread::spawn(move || gc.on_all(cidf))
     }


### PR DESCRIPTION
Directly forward the output and input of attached containers to the caller instead of buffering them.

This fixes the issue of interactive apps getting stuck or terminating immediatly